### PR TITLE
Remove drag handlers from static theme circles

### DIFF
--- a/assets/js/synapse/core.js
+++ b/assets/js/synapse/core.js
@@ -607,16 +607,7 @@ function buildGraph() {
       .on("end", dragEnded)
   );
 
-  // Drag for theme circles
-  if (themeEls) {
-    themeEls.call(
-      d3
-        .drag()
-        .on("start", dragStarted)
-        .on("drag", dragged)
-        .on("end", dragEnded)
-    );
-  }
+  // Themes are static in concentric circles - no dragging needed
 
   // Tick
   let tickCount = 0;


### PR DESCRIPTION
Themes are now static SVG elements in concentric layout and should not be draggable. Removed drag handler setup that was causing initialization errors.

- Removed themeEls drag handler setup (lines 610-619)
- Themes remain fixed at canvas center
- Only nodes (projects and people) are draggable
- Should fix 'Synapse init skipped' error