### PR TITLE
🐛 Fix theme click handler TypeError with null safety

### DIFF
--- a/assets/js/synapse.js
+++ b/assets/js/synapse.js
@@ -13,4 +13,4 @@ export {
   getRecommendations,
   // Theme API (new)
   refreshThemeCircles
-} from "./synapse/core.js?v=5";
+} from "./synapse/core.js?v=6";

--- a/assets/js/synapse/core.js
+++ b/assets/js/synapse/core.js
@@ -1,6 +1,6 @@
 // assets/js/synapse/core.js
 // Synapse Core — init, svg, simulation wiring (modularized)
-// Version: 5.0 - Fixed async/await in BOTH rebuildGraph AND buildGraph (2026-01-13)
+// Version: 6.0 - Fixed theme click handler null safety (2026-01-13)
 
 import { initConnections } from "../connections.js";
 import { openNodePanel } from "../node-panel.js";
@@ -1009,6 +1009,7 @@ async function openThemeCard(themeNode) {
   });
 
   nodeEls?.style("opacity", (d) => {
+    if (!d) return 0.2;
     if (d.type === "project" && relatedProjects.some((p) => p.id === d.id)) {
       return 1;
     }
@@ -1016,16 +1017,17 @@ async function openThemeCard(themeNode) {
   });
 
   linkEls?.style("opacity", (d) => {
-    const sourceId = typeof d.source === "object" ? d.source.id : d.source;
-    const targetId = typeof d.target === "object" ? d.target.id : d.target;
+    if (!d) return 0.1;
+    const sourceId = typeof d.source === "object" ? d.source?.id : d.source;
+    const targetId = typeof d.target === "object" ? d.target?.id : d.target;
 
     const isRelatedLink = relatedProjects.some(
-      (p) => sourceId === p.id || targetId === p.id
+      (p) => sourceId === p?.id || targetId === p?.id
     );
     return isRelatedLink ? 0.6 : 0.1;
   });
 
-  themeEls?.style("opacity", (d) => (d.id === themeNode.id ? 1 : 0.3));
+  themeEls?.style("opacity", (d) => (d?.id === themeNode?.id ? 1 : 0.3));
 
   await openThemeProjectsPanel(themeNode, relatedProjects);
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -758,7 +758,7 @@
   <script type="module" src="profile.js"></script>
 
    <!-- Synapse boot -->
-  <script type="module" src="assets/js/synapse.js?v=5"></script>
+  <script type="module" src="assets/js/synapse.js?v=6"></script>
 
   <!-- Main app boot -->
   <script type="module" src="main.js"></script>


### PR DESCRIPTION
Added null safety checks to prevent "Cannot read properties of undefined" error when clicking on theme nodes in the synapse view.

Issue: When clicking theme nodes, D3 selection callbacks sometimes received undefined data, causing crashes at line 1028.

Fix:
- Added optional chaining (d?.id) in theme opacity callback
- Added null checks (!d) in node and link opacity callbacks
- Added optional chaining for source/target id access
- Bumped version to 6.0 and cache parameter to v=6

This prevents crashes while maintaining visual highlighting behavior when filtering nodes/links related to a clicked theme.

Error resolved: core.js:1028 TypeError: Cannot read properties of undefined (reading 'id')