### PR TITLE
Fix skills parsing error in project request management

### DIFF
--- a/assets/js/node-panel.js
+++ b/assets/js/node-panel.js
@@ -1472,7 +1472,14 @@ window.manageProjectRequests = async function(projectId) {
             </div>
           ` : pendingRequests.map(request => {
             const user = request.user;
-            const skills = user.skills || [];
+            // Parse skills - could be string (comma-separated) or array
+            let skills = user.skills || [];
+            if (typeof skills === 'string') {
+              skills = skills.split(',').map(s => s.trim()).filter(Boolean);
+            }
+            if (!Array.isArray(skills)) {
+              skills = [];
+            }
             return `
               <div style="background: rgba(255,107,107,0.05); border: 1px solid rgba(255,107,107,0.2); border-radius: 12px; padding: 1.25rem; margin-bottom: 1rem;" data-request-id="${request.id}">
                 <div style="display: flex; gap: 1rem; align-items: start;">


### PR DESCRIPTION
Fixed TypeError when managing project requests where skills.slice(...).map failed because skills could be a string instead of an array.

The issue occurred in manageProjectRequests when displaying pending join requests. The skills field from the database can be either:
- A comma-separated string (e.g., "React, Node.js, Python")
- An array (e.g., ["React", "Node.js", "Python"])
- null/undefined

The code now properly handles all cases:
1. Checks if skills is a string and splits by comma
2. Trims whitespace from each skill
3. Filters out empty strings
4. Falls back to empty array if not an array

This matches the parseSkills helper used elsewhere in the codebase.