### PR TITLE
fix: correct module imports and add Create Organization button

### DIFF
--- a/opportunities.html
+++ b/opportunities.html
@@ -441,8 +441,8 @@
   </div>
 
   <!-- Supabase Client -->
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <script src="assets/js/supabaseClient.js"></script>
+  
+  <script type="module" src="assets/js/supabaseClient.js"></script>
 
   <!-- Organization Modules -->
   <script type="module">

--- a/organization-admin.html
+++ b/organization-admin.html
@@ -311,8 +311,8 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <script src="assets/js/supabaseClient.js"></script>
+  
+  <script type="module" src="assets/js/supabaseClient.js"></script>
 
   <script type="module">
     import { initOrganizationManager, createOrganization } from './assets/js/organizations/organization-manager.js';

--- a/organization-profile.html
+++ b/organization-profile.html
@@ -530,8 +530,8 @@
   </div>
 
   <!-- Supabase Client -->
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <script src="assets/js/supabaseClient.js"></script>
+  
+  <script type="module" src="assets/js/supabaseClient.js"></script>
 
   <!-- Organization Modules -->
   <script type="module">

--- a/organizations.html
+++ b/organizations.html
@@ -454,6 +454,11 @@
     <div class="page-header">
       <h1>Discover Organizations</h1>
       <p>Connect with companies, nonprofits, and groups in the CharlestonHacks community</p>
+      <div style="margin-top: 1.5rem;">
+        <a href="/organization-admin.html" class="btn btn-primary">
+          <i class="fas fa-plus"></i> Create Organization
+        </a>
+      </div>
     </div>
 
     <!-- Controls -->
@@ -523,8 +528,7 @@
   </div>
 
   <!-- Supabase Client -->
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <script src="assets/js/supabaseClient.js"></script>
+  <script type="module" src="assets/js/supabaseClient.js"></script>
 
   <!-- Organization Modules -->
   <script type="module">


### PR DESCRIPTION
Fixed two critical issues with the Organizations feature:

1. **Module Import Errors**
   - Changed supabaseClient.js to load as type="module"
   - Removed duplicate CDN script tag
   - Now properly imports as ES6 module
   - Fixed "Cannot use import statement outside a module" error
   - Applied fix to all 4 organization pages

2. **Added Create Organization Button**
   - Added prominent "Create Organization" button to organizations.html header
   - Button navigates to /organization-admin.html
   - Makes it clear how users can add new organizations
   - Previously there was no visible way to create organizations

Files updated:
- organizations.html
- opportunities.html
- organization-profile.html
- organization-admin.html

The Organizations feature should now load without errors.