### PR TITLE
🔧 Add ES module exports to connections.js

### DIFF
--- a/assets/js/connections.js
+++ b/assets/js/connections.js
@@ -672,3 +672,25 @@ if (typeof window !== "undefined") {
   window.removeConnection = removeConnection;
   window.formatTimeAgo = formatTimeAgo;
 }
+
+// ========================
+// ES MODULE EXPORTS
+// ========================
+export {
+  initConnections,
+  refreshCurrentUser,
+  getCurrentUserCommunityId,
+  getConnectionBetween,
+  getConnectionStatus,
+  getAllConnectionsForSynapse,
+  canSeeEmail,
+  getAcceptedConnections,
+  getPendingRequestsReceived,
+  getPendingRequestsSent,
+  sendConnectionRequest,
+  acceptConnectionRequest,
+  declineConnectionRequest,
+  cancelConnectionRequest,
+  removeConnection,
+  formatTimeAgo,
+};


### PR DESCRIPTION
Fixed critical import errors by adding proper named exports for all connection management functions. This resolves:
- acceptConnectionRequest import in connectionRequests.js
- getCurrentUserCommunityId import in pathway-animations.js

The file had all functions defined but only exposed them via window object, not as ES module exports.