### PR TITLE
🐛 Fix view toggle to properly reset state when switching

### DIFF
--- a/assets/js/synapse/core-cards.js
+++ b/assets/js/synapse/core-cards.js
@@ -107,6 +107,22 @@ export async function refreshSynapseConnections() {
   await rebuildInterface();
 }
 
+export function resetSynapseView() {
+  console.log("🔄 Resetting Synapse Cards view state");
+  initialized = false;
+
+  // Clear simulation if it exists
+  if (simulation) {
+    simulation.stop();
+    simulation = null;
+  }
+
+  // Clear any running animations
+  if (window.PathwayAnimations) {
+    window.PathwayAnimations.stopAll?.();
+  }
+}
+
 export function getSynapseStats() {
   const peopleCount = nodes.filter((n) => n.type === "person").length;
   const projectCount = nodes.filter((n) => n.type === "project").length;

--- a/assets/js/synapse/core.js
+++ b/assets/js/synapse/core.js
@@ -215,6 +215,22 @@ export async function toggleFullCommunityView(show) {
   }
 }
 
+export function resetSynapseView() {
+  console.log("🔄 Resetting Synapse Circles view state");
+  initialized = false;
+
+  // Clear simulation if it exists
+  if (simulation) {
+    simulation.stop();
+    simulation = null;
+  }
+
+  // Clear any running animations
+  if (window.PathwayAnimations) {
+    window.PathwayAnimations.stopAll?.();
+  }
+}
+
 export function getSynapseStats() {
   const peopleCount = nodes.filter((n) => n.type === "person").length;
   const projectCount = nodes.filter((n) => n.type === "project").length;

--- a/assets/js/theme-strategy-toggle.js
+++ b/assets/js/theme-strategy-toggle.js
@@ -78,6 +78,22 @@ async function toggleThemeStrategy() {
     }
     button.style.pointerEvents = 'none';
 
+    // Reset the current view's state before switching
+    console.log('🔄 Resetting current view state before switch...');
+    try {
+      if (currentStrategy === 'new') {
+        // We're in cards mode, reset cards before switching to circles
+        const { resetSynapseView } = await import('./synapse/core-cards.js');
+        resetSynapseView();
+      } else {
+        // We're in circles mode, reset circles before switching to cards
+        const { resetSynapseView } = await import('./synapse/core.js?v=2c0b13fcc6e615869bc4682741e11e2bcf047292');
+        resetSynapseView();
+      }
+    } catch (resetError) {
+      console.warn('⚠️ Failed to reset current view:', resetError);
+    }
+
     // Clear current synapse
     const synapseContainer = document.getElementById('synapse-svg')?.parentElement;
     if (synapseContainer) {
@@ -86,10 +102,10 @@ async function toggleThemeStrategy() {
 
     // Switch strategy
     currentStrategy = currentStrategy === 'old' ? 'new' : 'old';
-    
+
     // Update global reference
     window.currentStrategy = currentStrategy;
-    
+
     // Dynamically import and initialize the appropriate strategy
     if (currentStrategy === 'new') {
       // Import new cards strategy


### PR DESCRIPTION
The view toggle button was only working one-way (cards → circles) but not back. This was caused by the initialization guards in both core.js and core-cards.js that prevented re-initialization when the `initialized` flag was still true.

**Changes:**
- Added `resetSynapseView()` export to core-cards.js to reset initialization state
- Added `resetSynapseView()` export to core.js to reset initialization state
- Updated toggleThemeStrategy() to call resetSynapseView() before switching views
- Both reset functions also stop simulations and clear animations for clean state

**How it works:**
1. Before switching views, the current view's reset function is called
2. This clears the `initialized` flag and stops any running simulations
3. The container is cleared and set up for the new view
4. The new view can now initialize properly since its `initialized` flag is false

The toggle now works bidirectionally: Cards ↔ Circles