### PR TITLE
✨ Add 3-way view toggle and hide top Cards button

### DIFF
--- a/assets/js/theme-strategy-toggle.js
+++ b/assets/js/theme-strategy-toggle.js
@@ -1,9 +1,9 @@
 // assets/js/theme-strategy-toggle.js
-// Toggle between old SVG circles and new theme cards strategy
+// Toggle between old SVG circles, new theme cards, and sidebar strategies
 
 console.log("🎯 Theme Strategy Toggle loaded");
 
-let currentStrategy = 'new'; // Start with new strategy
+let currentStrategy = 'cards'; // Start with cards strategy ('circles', 'cards', 'sidebar')
 let isToggling = false;
 
 // Add toggle button to the page
@@ -37,15 +37,20 @@ function addThemeStrategyToggle() {
 
 function updateButtonText(button) {
   const strategies = {
-    old: {
+    circles: {
+      icon: 'fa-circle-notch',  // Circles icon
+      text: 'Circles',
+      fullText: 'Switch to Circles'
+    },
+    cards: {
       icon: 'fa-th-large',  // Cards icon
       text: 'Cards',
       fullText: 'Switch to Cards'
     },
-    new: {
-      icon: 'fa-circle-notch',  // Circles icon
-      text: 'Circles',
-      fullText: 'Switch to Circles'
+    sidebar: {
+      icon: 'fa-bars',  // Sidebar icon
+      text: 'Sidebar',
+      fullText: 'Switch to Sidebar'
     }
   };
 
@@ -81,13 +86,13 @@ async function toggleThemeStrategy() {
     // Reset the current view's state before switching
     console.log('🔄 Resetting current view state before switch...');
     try {
-      if (currentStrategy === 'new') {
-        // We're in cards mode, reset cards before switching to circles
-        const { resetSynapseView } = await import('./synapse/core-cards.js');
+      if (currentStrategy === 'circles') {
+        // We're in circles mode, reset circles before switching
+        const { resetSynapseView } = await import('./synapse/core.js?v=2c0b13fcc6e615869bc4682741e11e2bcf047292');
         resetSynapseView();
       } else {
-        // We're in circles mode, reset circles before switching to cards
-        const { resetSynapseView } = await import('./synapse/core.js?v=2c0b13fcc6e615869bc4682741e11e2bcf047292');
+        // We're in cards/sidebar mode, reset before switching
+        const { resetSynapseView } = await import('./synapse/core-cards.js');
         resetSynapseView();
       }
     } catch (resetError) {
@@ -100,44 +105,55 @@ async function toggleThemeStrategy() {
       synapseContainer.innerHTML = '';
     }
 
-    // Switch strategy
-    currentStrategy = currentStrategy === 'old' ? 'new' : 'old';
+    // Cycle through strategies: circles -> cards -> sidebar -> circles
+    const strategies = ['circles', 'cards', 'sidebar'];
+    const currentIndex = strategies.indexOf(currentStrategy);
+    currentStrategy = strategies[(currentIndex + 1) % strategies.length];
 
     // Update global reference
     window.currentStrategy = currentStrategy;
 
     // Dynamically import and initialize the appropriate strategy
-    if (currentStrategy === 'new') {
-      // Import new cards strategy
-      const { initSynapseView } = await import('./synapse/core-cards.js');
-      
-      // Setup container for cards
-      setupCardsContainer();
-      
-      // Initialize new system
-      await initSynapseView();
-      
-      showNotification('🎯 Switched to Theme Cards Strategy!', 'success');
-      
-    } else {
+    if (currentStrategy === 'circles') {
       // Import old circles strategy
       const { initSynapseView } = await import('./synapse/core.js?v=2c0b13fcc6e615869bc4682741e11e2bcf047292');
-      
+
       // Setup container for SVG
       setupSVGContainer();
-      
+
       // Initialize old system
       await initSynapseView();
-      
-      showNotification('🔄 Switched to SVG Circles Strategy', 'info');
+
+      showNotification('🔄 Switched to Circles View', 'info');
+
+    } else {
+      // Import new cards strategy for both cards and sidebar modes
+      const { initSynapseView, toggleThemeDisplayMode } = await import('./synapse/core-cards.js');
+
+      // Setup container for cards
+      setupCardsContainer();
+
+      // Initialize new system
+      await initSynapseView();
+
+      // Set the appropriate display mode
+      if (currentStrategy === 'cards') {
+        toggleThemeDisplayMode('cards');
+        showNotification('🎯 Switched to Cards View', 'success');
+      } else if (currentStrategy === 'sidebar') {
+        toggleThemeDisplayMode('sidebar');
+        showNotification('📱 Switched to Sidebar View', 'success');
+      }
     }
 
   } catch (error) {
     console.error('❌ Failed to switch theme strategy:', error);
     showNotification('Failed to switch strategy: ' + error.message, 'error');
-    
+
     // Revert strategy on error
-    currentStrategy = currentStrategy === 'old' ? 'new' : 'old';
+    const strategies = ['circles', 'cards', 'sidebar'];
+    const currentIndex = strategies.indexOf(currentStrategy);
+    currentStrategy = strategies[(currentIndex - 1 + strategies.length) % strategies.length];
   } finally {
     isToggling = false;
     button.style.pointerEvents = 'auto';

--- a/dashboard.html
+++ b/dashboard.html
@@ -567,13 +567,13 @@
       <svg id="synapse-svg" style="width:100%; height:100%; background: #000000;"></svg>
     </div>
 
-    <!-- Discovery Mode / Cards View Toggle Button -->
+    <!-- Discovery Mode / Cards View Toggle Button - HIDDEN (moved to bottom bar) -->
     <button id="toggle-discovery-btn"
       style="position: fixed; top: 80px; left: 20px; z-index: 1500;
              background: linear-gradient(135deg, #00ff88, #00e0ff);
              border: 2px solid #00ff88; border-radius: 8px; color: #000;
              padding: 0.75rem 1rem; cursor: pointer; font-weight: bold;
-             font-size: 0.9rem; display: flex; align-items: center; gap: 0.5rem;
+             font-size: 0.9rem; display: none; align-items: center; gap: 0.5rem;
              backdrop-filter: blur(10px); box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
              transition: all 0.3s ease;">
       <i class="fas fa-th-large"></i>


### PR DESCRIPTION
Enhanced the bottom bar view toggle to cycle through three modes: Circles -> Cards -> Sidebar -> (repeat)

Changes:
- Modified theme-strategy-toggle.js to support 3-way cycling
  - Added 'sidebar' mode alongside 'circles' and 'cards'
  - Updated button icons: circles (fa-circle-notch), cards (fa-th-large), sidebar (fa-bars)
  - Toggle now cycles through all 3 modes instead of just 2
  - Properly initializes cards strategy with correct display mode
- Hidden the top-left "Cards View" button (#toggle-discovery-btn)
  - This functionality is now consolidated in the bottom bar
  - Set display: none to hide the button

User can now use single bottom bar button to switch between all view modes