### PR TITLE
🐛 Fix connections table column names in notifications

### DIFF
--- a/NOTIFICATION_WIRING_GUIDE.md
+++ b/NOTIFICATION_WIRING_GUIDE.md
@@ -99,7 +99,15 @@ async function getUnreadMessagesCount() {
 
 **Database Schema Needed:**
 ```sql
--- Already exists based on messaging.js:
+-- Already exists:
+CREATE TABLE connections (
+  id UUID PRIMARY KEY,
+  from_user_id UUID REFERENCES community(id),
+  to_user_id UUID REFERENCES community(id),
+  status TEXT,  -- 'pending', 'accepted', 'declined'
+  created_at TIMESTAMP
+);
+
 CREATE TABLE conversations (
   id UUID PRIMARY KEY,
   participant_1_id UUID REFERENCES community(id),


### PR DESCRIPTION
The connections table uses from_user_id/to_user_id, not user_id_a/user_id_b.

Fixes:
1. getConnectionRequestsCount() now queries to_user_id (not user_id_b)
2. Real-time INSERT listener uses to_user_id filter
3. Real-time UPDATE listener uses from_user_id filter
4. getUserName calls use from_user_id and to_user_id (not user_id_a/b)
5. Fixed count query to use { count } destructuring

Schema (verified from connections.js):
- from_user_id: person who sent the request
- to_user_id: person receiving the request
- status: 'pending', 'accepted', 'declined'

This matches how connections.js queries the table:
- getPendingRequestsReceived() uses to_user_id
- getPendingRequestsSent() uses from_user_id

Error before: 400 Bad Request (invalid column name)
After: Queries work with correct schema