### PR TITLE
Update network view: My Network default, Discovery Mode shows suggest…

### DIFF
--- a/assets/js/synapse/core.js
+++ b/assets/js/synapse/core.js
@@ -53,7 +53,7 @@ let currentUserCommunityId = null;
 
 let initialized = false;
 let projectCircles = null;
-let showFullCommunity = true; // Default to Discovery Mode (show full community)
+let showFullCommunity = false; // Default to My Network (not Discovery Mode)
 let userManuallyToggledMode = false; // Track if user manually changed the mode
 
 /* ==========================================================================
@@ -893,26 +893,10 @@ async function buildGraph() {
     console.log("🔍 All nodes:", nodes.map(n => ({ id: n.id, type: n.type, hidden: n.hidden })));
   }
 
-  // If no visible nodes, automatically enable discovery mode for new users
-  // BUT only if user hasn't manually toggled the mode
-  if (visibleNodes.length <= 10 && !userManuallyToggledMode) { // Limited content - enable discovery
-    console.log("🔍 Limited content found, enabling discovery mode...");
-    if (!showFullCommunity) {
-      showFullCommunity = true;
-      window.synapseShowFullCommunity = showFullCommunity; // Update global state
-      console.log("🌐 Discovery mode enabled - reloading data...");
-      
-      // Update button if it exists
-      if (typeof window.updateDiscoveryButtonState === 'function') {
-        window.updateDiscoveryButtonState();
-      }
-      
-      await reloadAllData();
-      await rebuildGraph();
-      return;
-    }
-  } else if (visibleNodes.length <= 10 && userManuallyToggledMode) {
-    console.log("🔍 Limited content found, but user manually toggled mode - respecting user choice");
+  // Auto-enable Discovery Mode is now disabled - users must manually click the button
+  // This respects user preference to start with "My Network" view
+  if (visibleNodes.length <= 10 && !userManuallyToggledMode) {
+    console.log("🔍 Limited content found. Discovery Mode available via button.");
   }
 
   // ✅ Use only visible nodes and links for simulation


### PR DESCRIPTION
…ed connections only

- Changed default view to 'My Network' (showFullCommunity = false)
- Disabled auto-enable Discovery Mode logic for users with limited content
- Discovery Mode now only shows suggested connections (users not already connected)
- Discovery Mode only loads when user clicks the Discovery Mode button
- My Network shows only direct connections and participated themes
- Added logging to help debug Discovery Mode vs My Network loading