### PR TITLE
chore: bust CSS/JS cache to force mobile fixes to load

### DIFF
--- a/assets/css/connections.css
+++ b/assets/css/connections.css
@@ -779,6 +779,18 @@
 /* MOBILE RESPONSIVE */
 /* ======================== */
 @media (max-width: 768px) {
+  /* Profile card: clamp width, center horizontally, float above search bar */
+  .synapse-profile-card {
+    width: min(300px, calc(100vw - 32px)) !important;
+    left: 50% !important;
+    transform: translateX(-50%) !important;
+    top: auto !important;
+    bottom: 150px !important; /* above search bar */
+    right: auto !important;
+    max-height: calc(100vh - 220px);
+    overflow-y: auto;
+  }
+
   .connection-requests-panel {
     top: 70px;
     right: 10px;
@@ -834,7 +846,7 @@
   }
 
   .connections-fab {
-    bottom: 20px;
+    bottom: 196px; /* above mode switcher (~64px) + 132px base */
     right: 20px;
     width: 52px;
     height: 52px;

--- a/assets/css/synapse-progressive-disclosure.css
+++ b/assets/css/synapse-progressive-disclosure.css
@@ -24,11 +24,11 @@
   transition: all 0.3s ease;
 }
 
-/* Mobile: Bottom navigation */
+/* Mobile: Bottom navigation — sits above the search bar (~130px) */
 @media (max-width: 767px) {
   .synapse-mode-switcher {
     top: auto;
-    bottom: 20px;
+    bottom: 132px; /* above search container (~114px) + 16px gap */
     right: 50%;
     transform: translateX(50%);
     flex-direction: row;

--- a/assets/js/synapse/core.js
+++ b/assets/js/synapse/core.js
@@ -1683,6 +1683,23 @@ async function buildGraph() {
       }
     }
 
+    // Mobile boundary clamping: keep nodes inside visible viewport
+    // Accounts for top UI chrome (~70px) and bottom search bar (~130px on mobile)
+    const isMobile = window.innerWidth < 768;
+    if (isMobile) {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      const topPad = 70;    // below top nav/header
+      const botPad = 140;   // above bottom search bar + mode switcher
+      const sidePad = 40;   // left/right edge buffer
+      visibleNodes.forEach((d) => {
+        if (d.type === "theme") return; // themes are pinned separately
+        const r = d.isCurrentUser ? 55 : (d.shouldShowImage ? 30 : 24);
+        if (d.x != null) d.x = Math.max(sidePad + r, Math.min(w - sidePad - r, d.x));
+        if (d.y != null) d.y = Math.max(topPad + r, Math.min(h - botPad - r, d.y));
+      });
+    }
+
     // Update link positions - simplified for single line elements
     linkEls
       .attr("x1", (d) => d.source.x)

--- a/assets/js/unified-network/node-renderer.js
+++ b/assets/js/unified-network/node-renderer.js
@@ -211,9 +211,20 @@ export class NodeRenderer {
     nodeMerge.each((d, i, nodes) => {
       const element = nodes[i];
       const visualState = this.getVisualState(d, state);
-      
+
+      // Mobile boundary clamping: keep nodes inside visible viewport
+      // Accounts for top UI chrome (~70px) and bottom search/mode-switcher (~200px)
+      let x = d.x ?? 0;
+      let y = d.y ?? 0;
+      if (window.innerWidth < 768) {
+        const r = (visualState.radius || 24) + 4;
+        const sidePad = 40;
+        x = Math.max(sidePad + r, Math.min(window.innerWidth - sidePad - r, x));
+        y = Math.max(70 + r, Math.min(window.innerHeight - 200 - r, y));
+      }
+
       // Use CSS transform for GPU acceleration
-      element.style.transform = `translate(${d.x}px, ${d.y}px) scale(${visualState.scale})`;
+      element.style.transform = `translate(${x}px, ${y}px) scale(${visualState.scale})`;
       element.style.opacity = visualState.opacity;
     });
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -173,11 +173,11 @@
       #btn-refresh-network {
         position: fixed !important;
         top: auto !important;
-        bottom: 80px !important; /* Above search bar */
+        bottom: 260px !important; /* above FAB (196px) + 64px clearance */
         right: 20px !important;
         z-index: 1000 !important;
-        width: 56px !important;
-        height: 56px !important;
+        width: 48px !important;
+        height: 48px !important;
         box-shadow: 0 4px 12px rgba(0,224,255,0.3) !important;
       }
 
@@ -485,9 +485,9 @@
         display: none !important;
       }
 
-      /* Search container - move down significantly */
+      /* Search container - anchored at bottom with safe area inset */
       #centered-search-container {
-        bottom: 20px !important; /* Move to bottom with more space */
+        bottom: max(16px, env(safe-area-inset-bottom, 16px)) !important;
         width: calc(100vw - 20px) !important;
         max-width: calc(100vw - 20px) !important;
         left: 10px !important;

--- a/dashboard.html
+++ b/dashboard.html
@@ -17,11 +17,11 @@
   <link rel="stylesheet" href="assets/css/base.css" />
   <link rel="stylesheet" href="assets/css/engine.css" />
   <link rel="stylesheet" href="assets/css/overlays.css" />
-  <link rel="stylesheet" href="assets/css/connections.css" />
+  <link rel="stylesheet" href="assets/css/connections.css?v=mobile-fix-20260405" />
   <link rel="stylesheet" href="assets/css/cynq.css" />
   <link rel="stylesheet" href="assets/css/messaging.css" />
-  <link rel="stylesheet" href="dashboard.css" />
-  <link rel="stylesheet" href="assets/css/synapse-progressive-disclosure.css" />
+  <link rel="stylesheet" href="dashboard.css?v=mobile-fix-20260405" />
+  <link rel="stylesheet" href="assets/css/synapse-progressive-disclosure.css?v=mobile-fix-20260405" />
   <link rel="stylesheet" href="assets/css/quiet-mode.css" />
 
   <!-- Icons -->
@@ -1452,7 +1452,7 @@
   <script type="module" src="assets/js/synapse.js?v=fc09b39b-1770146154f916933b2da"></script>
 
   <!-- Unified Network Discovery Integration (Feature Flag Controlled) -->
-  <script type="module" src="assets/js/unified-network-integration.js?v=fc09b39b-17701461547"></script>
+  <script type="module" src="assets/js/unified-network-integration.js?v=mobile-fix-20260405"></script>
   
   <!-- Presence Session Manager (Creates and maintains presence sessions) -->
   <script src="assets/js/presence-session-manager.js?v=20260208-1"></script>


### PR DESCRIPTION
Bumps version strings on connections.css, dashboard.css, synapse-progressive-disclosure.css, and unified-network-integration.js so browsers are forced to re-fetch the updated files rather than serving cached versions.