### PR TITLE
Remove duplicate logo and tagline from splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,7 @@
   <!-- Enhanced Splash Screen -->
   <div id="splash-overlay" role="dialog" aria-modal="true" aria-labelledby="splash-title">
     <div id="splash-content">
-      <img src="images/charlestonhackslogo.svg" style="width:220px;" alt="CharlestonHacks Logo"/>
       <h1 id="splash-title">Welcome to CharlestonHacks</h1>
-      <p id="splash-desc">Making Invisible Networks Visible</p>
 
       <label style="margin-top:1.5em;font-size:.9rem;display:block;">
         <input type="checkbox" id="dont-show-again"> Don't show this again


### PR DESCRIPTION
Removes the second CharlestonHacks logo image inside the splash overlay (the top-fixed logo already displays it) and removes the "Making Invisible Networks Visible" tagline paragraph.

https://claude.ai/code/session_016YCSRPtSr7YBshRHaEKosv