### PR TITLE
Fix swag voting: duplicate Mug names, broken upsert, silent failures

### DIFF
--- a/supabase/sql/tables/CREATE_SWAG_VOTES.sql
+++ b/supabase/sql/tables/CREATE_SWAG_VOTES.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- MANUAL SUPABASE SCRIPT
+-- ============================================================================
+-- Applied via Supabase Dashboard or CLI
+-- Not executed by application code
+-- ============================================================================
+-- Run this script once in your Supabase SQL editor to enable swag voting.
+-- ============================================================================
+
+
+-- ============================================================================
+-- CREATE SWAG_VOTES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.swag_votes (
+  swag   TEXT PRIMARY KEY,
+  votes  INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Keep updated_at current on every write
+CREATE OR REPLACE FUNCTION public.set_swag_votes_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_swag_votes_updated_at ON public.swag_votes;
+CREATE TRIGGER trg_swag_votes_updated_at
+  BEFORE UPDATE ON public.swag_votes
+  FOR EACH ROW EXECUTE FUNCTION public.set_swag_votes_updated_at();
+
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- ============================================================================
+ALTER TABLE public.swag_votes ENABLE ROW LEVEL SECURITY;
+
+-- Anyone (including unauthenticated visitors) can read vote counts
+CREATE POLICY "swag_votes_public_select"
+  ON public.swag_votes FOR SELECT
+  USING (true);
+
+-- Anyone can insert a new swag row (first vote for that item)
+CREATE POLICY "swag_votes_public_insert"
+  ON public.swag_votes FOR INSERT
+  WITH CHECK (true);
+
+-- Anyone can update an existing swag row (subsequent votes)
+CREATE POLICY "swag_votes_public_update"
+  ON public.swag_votes FOR UPDATE
+  USING (true)
+  WITH CHECK (true);

--- a/swag.html
+++ b/swag.html
@@ -294,8 +294,8 @@
       { name: "Hat1", img: "icons/hat1.webp" },
       { name: "Hat2", img: "icons/hat2.webp" },
       { name: "Hoodie", img: "icons/hoodie.webp" },
-      { name: "Mug", img: "icons/mug1.webp" },
-      { name: "Mug", img: "icons/mug2.webp" },
+      { name: "Mug 1", img: "icons/mug1.webp" },
+      { name: "Mug 2", img: "icons/mug2.webp" },
       { name: "Gauntlet", img: "icons/gauntlet.webp" }
     ];
 
@@ -362,38 +362,42 @@
 
     async function voteForSwag(swagName) {
       try {
-        const { data, error } = await supabase.from('swag_votes').select('*').eq('swag', swagName).single();
-        if (error && error.code !== "PGRST116") {
-          // PGRST116 = No rows found (depends on PostgREST version); treat other errors as real
-          console.warn("Select error:", error);
-        }
+        const { data, error: selErr } = await supabase
+          .from('swag_votes')
+          .select('votes')
+          .eq('swag', swagName)
+          .maybeSingle();
 
-        let currentVotes = data?.votes || 0;
+        if (selErr) throw selErr;
 
-        if (data) {
-          const { error: upErr } = await supabase
-            .from('swag_votes')
-            .update({ votes: currentVotes + 1 })
-            .eq('swag', swagName);
-          if (upErr) throw upErr;
-        } else {
-          const { error: insErr } = await supabase
-            .from('swag_votes')
-            .insert([{ swag: swagName, votes: 1 }]);
-          if (insErr) throw insErr;
-        }
+        const newVotes = (data?.votes ?? 0) + 1;
+
+        const { error: upsErr } = await supabase
+          .from('swag_votes')
+          .upsert({ swag: swagName, votes: newVotes }, { onConflict: 'swag' });
+
+        if (upsErr) throw upsErr;
 
         showVoteOverlay(swagName);
         loadLeaderboard();
       } catch (err) {
         console.error("Voting error:", err);
+        showVoteOverlay(null, err.message || "Vote failed — please try again.");
       }
     }
 
-    function showVoteOverlay(swagName) {
-      voteOverlay.textContent = `Vote Registered for ${swagName}!`;
+    function showVoteOverlay(swagName, errMsg) {
+      if (errMsg) {
+        voteOverlay.textContent = errMsg;
+        voteOverlay.style.background = "rgba(220,50,50,0.95)";
+        voteOverlay.style.color = "#fff";
+      } else {
+        voteOverlay.textContent = `Vote Registered for ${swagName}!`;
+        voteOverlay.style.background = "";
+        voteOverlay.style.color = "";
+      }
       voteOverlay.classList.add('active');
-      setTimeout(() => voteOverlay.classList.remove('active'), 1500);
+      setTimeout(() => voteOverlay.classList.remove('active'), 2000);
     }
 
     lightboxVote.onclick = () => voteForSwag(swagItems[currentIndex].name);


### PR DESCRIPTION
- Rename both "Mug" items to "Mug 1" / "Mug 2" — duplicate keys caused both to share one DB row and show a single leaderboard entry
- Replace .single() + separate insert/update with .maybeSingle() + upsert so the write path is one operation and won't silently leave the row in a bad state on a race
- Surface DB errors to the user (red overlay) instead of only console.error
- Add CREATE_SWAG_VOTES.sql migration with RLS policies that allow anonymous SELECT / INSERT / UPDATE — the most likely root cause of votes never persisting in production

https://claude.ai/code/session_01A9cUJaCq9Q3Jekyio8A5K4