### PR TITLE
Fix swag voting: point to active Supabase project URL

### DIFF
--- a/swag.html
+++ b/swag.html
@@ -284,7 +284,7 @@
     import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.2/+esm";
 
     const supabase = createClient(
-      "https://hvmotpzhliufzomewzfl.supabase.co",
+      "https://mqbsjlgnsirqsmfnreqd.supabase.co",
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh2bW90cHpobGl1ZnpvbWV3emZsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI1NzY2NDUsImV4cCI6MjA1ODE1MjY0NX0.foHTGZVtRjFvxzDfMf1dpp0Zw4XFfD-FPZK-zRnjc6s"
     );
 


### PR DESCRIPTION
swag.html was still using the old deleted project
(hvmotpzhliufzomewzfl), causing ERR_NAME_NOT_RESOLVED on every vote and leaderboard request. Updated to the active project URL (mqbsjlgnsirqsmfnreqd) that the rest of the site already uses.

https://claude.ai/code/session_01A9cUJaCq9Q3Jekyio8A5K4