### PR TITLE
Improve UX, accessibility, and content clarity across homepage and su…

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,6 @@
 
   <!-- Preload key visuals -->
   <link rel="preload" as="image" href="icons/card.png">
-  <!-- ✅ Preloaded (but NOT used as the visible header logo) -->
-  <link rel="preload" as="image" href="images/charlestonhackslogo.svg">
-  <!-- ✅ Visible header logo asset -->
   <link rel="preload" as="image" href="images/charlestonhackslogo.svg">
 
   <!-- Neuron redirect (keeps querystring, removes source=neuron) -->
@@ -36,7 +33,7 @@
     gtag("config", "G-6NDKG07DY6");
   </script>
 
-  <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <title>CharlestonHacks - Portal to Innovation</title>
   <meta name="description" content="CharlestonHacks — Making Invisible Networks Visible. Explore interactive portals to innovation, community, and collaboration."/>
   <meta property="og:image" content="images/websitepanel.webp"/>
@@ -78,31 +75,61 @@
       .ch-top-logo { top: 10px; }
       .ch-top-logo img { width: min(92vw, 260px); }
     }
+
+    .ch-tagline {
+      position: fixed;
+      top: 72px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 9998;
+      margin: 0;
+      color: rgba(255, 255, 255, 0.55);
+      font-size: clamp(0.65rem, 1.8vw, 0.8rem);
+      letter-spacing: 0.1em;
+      text-align: center;
+      white-space: nowrap;
+      pointer-events: none;
+      text-shadow: 0 1px 6px rgba(0, 0, 0, 0.9);
+      font-family: 'Orbitron', sans-serif;
+      text-transform: uppercase;
+    }
+    @media (max-width: 640px) {
+      .ch-tagline { top: 62px; font-size: 0.6rem; }
+    }
   </style>
 </head>
 
 <body>
   <canvas id="neural-bg"></canvas>
 
-  <!-- ✅ NEW: Top-center visible logo -->
+  <!-- Top-center visible logo -->
   <div class="ch-top-logo" aria-hidden="true">
     <img src="images/charlestonhackslogo.svg" alt="">
   </div>
+  <p class="ch-tagline">Charleston's community for builders, hackers &amp; makers</p>
 
-  <!-- Enhanced Splash Screen -->
+  <!-- Splash Screen -->
   <div id="splash-overlay" role="dialog" aria-modal="true" aria-labelledby="splash-title">
     <div id="splash-content">
       <h1 id="splash-title">Welcome to CharlestonHacks</h1>
+      <p style="font-size:.9rem;opacity:.8;margin:.5rem 0 1.5rem;line-height:1.6;">
+        Charleston's community for builders, hackers &amp; makers.<br>
+        Where would you like to go?
+      </p>
 
-      <label style="margin-top:1.5em;font-size:.9rem;display:block;">
+      <label style="font-size:.85rem;display:block;margin-bottom:1.5rem;">
         <input type="checkbox" id="dont-show-again"> Don't show this again
       </label>
 
-      <div style="margin-top:1.5rem;">
-        <button id="community-site-btn" class="btn">Innovation Engine</button>
+      <div style="display:flex;flex-direction:column;gap:.75rem;">
+        <button id="community-site-btn" class="btn">
+          Community Dashboard
+          <span style="display:block;font-size:.75rem;opacity:.7;font-weight:normal;margin-top:.2rem;">Connect with members · Innovation Engine</span>
+        </button>
         <button id="public-site-btn" class="btn"
           style="background:transparent;border:2px solid var(--cyan);color:var(--cyan);">
-          CharlestonHacks
+          Public Website
+          <span style="display:block;font-size:.75rem;opacity:.7;font-weight:normal;margin-top:.2rem;">News, newsletter &amp; announcements</span>
         </button>
       </div>
 
@@ -188,8 +215,8 @@
 
           <button type="button" class="clickable-area middle-right"
                   data-sound="chime" data-url="swag.html"
-                  data-info="🎁 Swag Store - Official CharlestonHacks merchandise"
-                  data-portal="swag" aria-label="Swag Store Portal">
+                  data-info="🗳️ Swag Vote - Vote on official CharlestonHacks merchandise"
+                  data-portal="swag" aria-label="Swag Vote Portal">
             <img src="images/case.webp" alt="">
           </button>
 
@@ -256,10 +283,10 @@
       <a href="mailto:hello@charlestonhacks.com" title="Email Us" aria-label="Email">
         <i class="fas fa-envelope"></i>
       </a>
-      <a href="https://www.facebook.com/deckerdb26354" target="_blank" title="Facebook" aria-label="Facebook">
+      <a href="https://www.facebook.com/charlestonhacks" target="_blank" title="Facebook" aria-label="Facebook">
         <i class="fab fa-facebook"></i>
       </a>
-      <a id="open-calendar" title="Charleston Events Calendar (coming soon)" aria-label="Events Calendar" style="cursor:pointer;">
+      <a id="open-calendar" title="Charleston Events Calendar" aria-label="Events Calendar" style="cursor:pointer;">
         <i class="fas fa-calendar-alt"></i>
       </a>
     </section>
@@ -268,7 +295,7 @@
   <!-- Events Modal -->
   <div id="events-overlay" role="dialog" aria-modal="true" aria-labelledby="events-title">
     <div class="events-modal">
-      <h2 id="events-title">Upcoming Charleston Events (feature in development)</h2>
+      <h2 id="events-title">Upcoming Charleston Events</h2>
       <div id="events-list" role="list"></div>
       <button id="close-overlay">Close</button>
     </div>

--- a/subscribe.html
+++ b/subscribe.html
@@ -10,39 +10,46 @@
     <link rel="stylesheet" href="styles.css">
     <style>
         body {
-            background-color: #f4f4f4;
+            background-color: #0a0a0a;
             font-family: Arial, sans-serif;
             margin: 0;
             padding: 0;
+            color: #e0e0e0;
         }
 
         #mc_embed_shell {
             display: flex;
             justify-content: center;
             align-items: center;
-            height: 100vh;
+            min-height: 100vh;
             padding: 20px;
         }
 
         #mc_embed_signup {
-            background: #fff;
+            background: #121212;
+            border: 1px solid #2a2a2a;
             width: 100%;
             max-width: 600px;
-            padding: 20px;
+            padding: 2rem;
             border-radius: 8px;
-            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.6);
             position: relative;
         }
 
         h2 {
-            color: #333;
+            color: #c9a35e;
             text-align: center;
+            margin-bottom: 1rem;
         }
 
         .indicates-required {
             text-align: center;
             margin-bottom: 20px;
+            color: #888;
+            font-size: .9rem;
         }
+
+        .asterisk { color: #00e0ff; }
 
         .mc-field-group {
             margin-bottom: 20px;
@@ -51,30 +58,44 @@
         label {
             display: block;
             margin-bottom: 5px;
-            color: #555;
+            color: #aaa;
+            font-size: .9rem;
         }
 
         input[type="email"],
         input[type="text"] {
             width: 100%;
             padding: 10px;
-            border: 1px solid #ddd;
+            background: #1e1e1e;
+            border: 1px solid #333;
             border-radius: 4px;
+            color: #e0e0e0;
+            box-sizing: border-box;
+            font-size: 1rem;
+        }
+
+        input[type="email"]:focus,
+        input[type="text"]:focus {
+            outline: none;
+            border-color: #00e0ff;
         }
 
         input[type="submit"] {
-            background-color: #007bff;
-            color: #fff;
-            padding: 10px 20px;
+            background-color: #c9a35e;
+            color: #000;
+            padding: 12px 20px;
             border: none;
             border-radius: 4px;
             cursor: pointer;
             width: 100%;
-            font-size: 16px;
+            font-size: 1rem;
+            font-weight: bold;
+            letter-spacing: .05em;
+            transition: background-color .2s;
         }
 
         input[type="submit"]:hover {
-            background-color: #0056b3;
+            background-color: #e0b96e;
         }
 
         .response {
@@ -84,20 +105,21 @@
 
         .home-icon {
             position: absolute;
-            top: 10px;
-            left: 10px;
-            font-size: 24px;
-            color: #000000;
+            top: 12px;
+            left: 14px;
+            font-size: 22px;
+            color: #888;
             cursor: pointer;
+            transition: color .2s;
         }
 
         .home-icon:hover {
-            color: #0056b3;
+            color: #00e0ff;
         }
 
         @media (max-width: 600px) {
             #mc_embed_signup {
-                padding: 15px;
+                padding: 1.25rem;
             }
         }
     </style>


### PR DESCRIPTION
…bscribe page

- Add persistent tagline ("Charleston's community for builders, hackers & makers") below the logo so first-time visitors immediately understand the site's purpose
- Rewrite splash screen: replace ambiguous "Innovation Engine" / "CharlestonHacks" buttons with clearly-labelled "Community Dashboard" and "Public Website", each with a short descriptor line
- Remove "coming soon" / "feature in development" copy from the Events Calendar since the Cloudflare Worker feed is fully wired up
- Remove user-scalable=no from viewport meta (WCAG 1.4.4 compliance)
- Restyle subscribe.html with the dark theme (#0a0a0a / #121212) used everywhere else on the site — eliminates the jarring light flash on navigation
- Replace personal Facebook profile URL with the org page URL
- Rename Swag Store portal label to "Swag Vote" to match what the page actually does
- Remove duplicate logo SVG preload tag in <head>

https://claude.ai/code/session_016v3tzEoDpwGjo7yETAyLto