### PR TITLE
Move tagline from top (overlapping logo) to bottom-center of viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,12 +78,12 @@
 
     .ch-tagline {
       position: fixed;
-      top: 72px;
+      bottom: 20px;
       left: 50%;
       transform: translateX(-50%);
       z-index: 9998;
       margin: 0;
-      color: rgba(255, 255, 255, 0.55);
+      color: rgba(255, 255, 255, 0.45);
       font-size: clamp(0.65rem, 1.8vw, 0.8rem);
       letter-spacing: 0.1em;
       text-align: center;
@@ -93,8 +93,9 @@
       font-family: 'Orbitron', sans-serif;
       text-transform: uppercase;
     }
-    @media (max-width: 640px) {
-      .ch-tagline { top: 62px; font-size: 0.6rem; }
+    /* On mobile the icon bar is fixed at the bottom — keep tagline above it */
+    @media (max-width: 768px) {
+      .ch-tagline { bottom: 68px; font-size: 0.6rem; }
     }
   </style>
 </head>


### PR DESCRIPTION
The fixed tagline at top:72px was colliding with the CharlestonHacks logo SVG which occupies the top-center. Repositioned to bottom:20px where there is open space on desktop (icon bar is a fixed right column) and adjusted mobile to bottom:68px to clear the fixed bottom icon bar.

https://claude.ai/code/session_016v3tzEoDpwGjo7yETAyLto