### PR TITLE
Add padding-top to main-wrapper to clear the fixed logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,12 @@
       .ch-top-logo img { width: min(92vw, 260px); }
     }
 
+    /* Push card below the fixed logo (logo bottom ≈ 119px desktop, 95px mobile) */
+    .main-wrapper { padding-top: 130px; }
+    @media (max-width: 640px) {
+      .main-wrapper { padding-top: 100px; }
+    }
+
     .ch-tagline {
       position: fixed;
       bottom: 20px;


### PR DESCRIPTION
Logo SVG is 841×277 viewBox; at 320px rendered width the height is ~105px placing its bottom at ~119px from top. Adding padding-top:130px on desktop and 100px on mobile gives a clean gap between the logo and the card top edge.

https://claude.ai/code/session_016v3tzEoDpwGjo7yETAyLto