### PR TITLE
Re-enable BBS on the dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -708,6 +708,16 @@
         <i class="fas fa-sync-alt" id="refresh-icon-header" style="color:#00e0ff; font-size:1.2rem;"></i>
       </div>
 
+      <!-- BBS Button -->
+      <div id="btn-bbs" style="cursor:pointer; padding:0.75rem; background:rgba(200,100,255,0.1);
+        border:1px solid rgba(200,100,255,0.3); border-radius:50%; width:48px; height:48px;
+        display:flex; align-items:center; justify-content:center; transition:all 0.2s;"
+        onmouseenter="this.style.background='rgba(200,100,255,0.2)'; this.style.borderColor='rgba(200,100,255,0.6)'"
+        onmouseleave="this.style.background='rgba(200,100,255,0.1)'; this.style.borderColor='rgba(200,100,255,0.3)'"
+        title="Community BBS">
+        <i class="fas fa-terminal" style="color:#c864ff; font-size:1.2rem;"></i>
+      </div>
+
       <!-- Logout Button -->
       <div id="btn-logout-header" onclick="if(window.handleLogout) { if(confirm('Are you sure you want to logout?')) window.handleLogout(); }" 
         style="cursor:pointer; padding:0.75rem; background:rgba(255,107,107,0.1);
@@ -2007,6 +2017,12 @@
 
 <!-- Unified Notification System (Replaces START button with enhanced notifications) -->
 <script src="assets/js/unified-notification-system.js?v=1"></script>
+
+<!-- BBS: import and expose initBBS globally for dashboard-actions.js -->
+<script type="module">
+  import { initBBS } from './assets/js/bbs.js';
+  window.initBBS = initBBS;
+</script>
 
 <!-- Daily Suggestions Engine -->
 <script type="module" src="assets/js/suggestions/index-v2.js"></script>


### PR DESCRIPTION
The BBS was fully built (bbs.js with Supabase real-time chat, Zork mode, online user tracking) but had no entry point. dashboard-actions.js already had the btn-bbs click handler; it just had no element to bind to.

- Add #btn-bbs nav button to the dashboard header bar (between Refresh and Logout), styled with purple/magenta to match the existing icon set
- Import bbs.js as an ES module and expose initBBS on window so the existing non-module dashboard-actions.js handler can call it

https://claude.ai/code/session_016v3tzEoDpwGjo7yETAyLto