### PR TITLE
Add countdown event banner and newsletter captcha

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,43 @@
       font-family: 'Orbitron', sans-serif;
       text-transform: uppercase;
     }
+
+    /* Countdown banner */
+    #event-countdown-banner {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 10001;
+      background: linear-gradient(90deg, rgba(0,30,40,0.96) 0%, rgba(0,12,20,0.98) 100%);
+      border-bottom: 1px solid rgba(0,224,255,0.25);
+      backdrop-filter: blur(6px);
+      padding: 6px 16px;
+      text-align: center;
+      font-family: 'Orbitron', monospace;
+      font-size: clamp(0.6rem, 2vw, 0.75rem);
+      letter-spacing: 0.08em;
+      color: rgba(255,255,255,0.85);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    #event-countdown-banner a {
+      color: #00e0ff;
+      text-decoration: none;
+    }
+    #event-countdown-banner a:hover { text-decoration: underline; }
+    #event-countdown-banner .cd-time { color: #00e0ff; font-weight: bold; }
+    #event-countdown-banner .cd-label { opacity: 0.6; margin-right: 6px; }
+    /* Shift logo + wrapper down when banner is visible */
+    body.has-countdown-banner .ch-top-logo { top: 44px; }
+    body.has-countdown-banner .main-wrapper { padding-top: 160px; }
+    @media (max-width: 768px) {
+      #event-countdown-banner { font-size: 0.58rem; padding: 5px 10px; }
+      body.has-countdown-banner .ch-top-logo { top: 38px; }
+      body.has-countdown-banner .main-wrapper { padding-top: 140px; }
+    }
   </style>
   <script type="application/ld+json">
   {
@@ -132,6 +169,9 @@
 </head>
 
 <body>
+  <!-- Upcoming event countdown bar -->
+  <div id="event-countdown-banner" role="status" aria-live="polite" aria-atomic="true"></div>
+
   <canvas id="neural-bg"></canvas>
 
   <!-- Top-center visible logo -->
@@ -385,5 +425,76 @@
 
   <!-- Portal logic -->
   <script type="module" src="/assets/js/portal.js"></script>
+
+  <!-- Countdown banner: fetches next event from the same feed as the calendar modal -->
+  <script type="module">
+    const FEED_URL = "https://charlestonhacks-events-worker.deckerdb26354.workers.dev";
+    const banner = document.getElementById("event-countdown-banner");
+
+    function pad(n) { return String(n).padStart(2, "0"); }
+
+    function renderCountdown(eventTitle, eventLink, target) {
+      const tick = () => {
+        const diff = target - Date.now();
+        if (diff <= 0) {
+          banner.style.display = "none";
+          document.body.classList.remove("has-countdown-banner");
+          return;
+        }
+        const days  = Math.floor(diff / 86400000);
+        const hrs   = Math.floor((diff % 86400000) / 3600000);
+        const mins  = Math.floor((diff % 3600000)  / 60000);
+        const secs  = Math.floor((diff % 60000)    / 1000);
+
+        const timeStr = days > 0
+          ? `${days}d ${pad(hrs)}h ${pad(mins)}m ${pad(secs)}s`
+          : `${pad(hrs)}h ${pad(mins)}m ${pad(secs)}s`;
+
+        const titleHtml = eventLink
+          ? `<a href="${eventLink}" target="_blank" rel="noopener noreferrer">${eventTitle}</a>`
+          : eventTitle;
+
+        banner.innerHTML =
+          `<span class="cd-label">NEXT EVENT</span>${titleHtml}&ensp;` +
+          `<span class="cd-time">${timeStr}</span>`;
+      };
+
+      banner.style.display = "block";
+      document.body.classList.add("has-countdown-banner");
+      tick();
+      setInterval(tick, 1000);
+    }
+
+    async function initCountdown() {
+      try {
+        const res = await fetch(FEED_URL);
+        if (!res.ok) return;
+        const data = await res.json();
+        const events = Array.isArray(data) ? data : (data?.events ?? []);
+
+        const now = Date.now();
+        const upcoming = events
+          .filter(e => e?.startDate && new Date(e.startDate).getTime() > now)
+          .sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
+
+        if (!upcoming.length) return;
+
+        const next = upcoming[0];
+        const target = new Date(next.startDate).getTime();
+        const title = String(next.title ?? "Upcoming Event")
+          .replace(/[<>&"]/g, c => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" }[c]));
+        const link = next.link ?? null;
+        renderCountdown(title, link, target);
+      } catch {
+        /* silently skip — banner stays hidden */
+      }
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", initCountdown);
+    } else {
+      initCountdown();
+    }
+  </script>
 </body>
 </html>

--- a/subscribe.html
+++ b/subscribe.html
@@ -98,6 +98,57 @@
             background-color: #e0b96e;
         }
 
+        .captcha-group {
+            margin-bottom: 20px;
+            padding: 14px 16px;
+            background: #1a1a1a;
+            border: 1px solid #333;
+            border-radius: 6px;
+        }
+
+        .captcha-group label {
+            color: #aaa;
+            font-size: .9rem;
+            margin-bottom: 8px;
+            display: block;
+        }
+
+        .captcha-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .captcha-question {
+            color: #00e0ff;
+            font-size: 1.05rem;
+            font-weight: bold;
+            white-space: nowrap;
+        }
+
+        #captcha-answer {
+            width: 80px;
+            padding: 8px 10px;
+            background: #1e1e1e;
+            border: 1px solid #444;
+            border-radius: 4px;
+            color: #e0e0e0;
+            font-size: 1rem;
+            text-align: center;
+        }
+
+        #captcha-answer:focus {
+            outline: none;
+            border-color: #00e0ff;
+        }
+
+        #captcha-error {
+            color: #ff6b6b;
+            font-size: .82rem;
+            margin-top: 6px;
+            display: none;
+        }
+
         .response {
             display: none;
             margin-top: 20px;
@@ -125,13 +176,34 @@
     </style>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            // Math captcha setup
+            const a = Math.floor(Math.random() * 9) + 1;
+            const b = Math.floor(Math.random() * 9) + 1;
+            const answer = a + b;
+            document.getElementById('captcha-question').textContent = `${a} + ${b} = ?`;
+
             const form = document.getElementById('mc-embedded-subscribe-form');
+            const captchaInput = document.getElementById('captcha-answer');
+            const captchaError = document.getElementById('captcha-error');
+
             form.addEventListener('submit', function(event) {
                 const emailInput = document.getElementById('mce-EMAIL');
                 if (!validateEmail(emailInput.value)) {
                     event.preventDefault();
                     alert('Please enter a valid email address.');
+                    return;
                 }
+                if (parseInt(captchaInput.value, 10) !== answer) {
+                    event.preventDefault();
+                    captchaError.style.display = 'block';
+                    captchaInput.focus();
+                    return;
+                }
+                captchaError.style.display = 'none';
+            });
+
+            captchaInput.addEventListener('input', function() {
+                captchaError.style.display = 'none';
             });
 
             function validateEmail(email) {
@@ -193,6 +265,15 @@
                     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
                     <div style="position: absolute; left: -5000px;" aria-hidden="true">
                         <input type="text" name="b_79363b7a43970f760d61360fd_3b95e0177a" tabindex="-1" value="">
+                    </div>
+                    <div class="captcha-group">
+                        <label for="captcha-answer">Quick check — prove you're human</label>
+                        <div class="captcha-row">
+                            <span class="captcha-question" id="captcha-question" aria-live="polite"></span>
+                            <input type="number" id="captcha-answer" autocomplete="off"
+                                   placeholder="?" aria-label="Captcha answer" min="0" max="99">
+                        </div>
+                        <div id="captcha-error" role="alert">Incorrect answer — please try again.</div>
                     </div>
                     <div class="clear">
                         <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">


### PR DESCRIPTION
- index.html: fixed top banner fetches next upcoming event from the events worker and counts down live (days/hours/minutes/seconds); auto-hides when no future events are found; shifts logo and main wrapper down so nothing is obscured
- subscribe.html: add client-side math captcha before the Mailchimp submit button to block trivial bot signups; styled to match the dark theme; answers are validated on submit with an inline error

Closes #9

https://claude.ai/code/session_01GNPvASqc3rGGEG9MXgCt1L