### PR TITLE
Add Community CTA page and wire into site navigation

### DIFF
--- a/assets/js/portal.js
+++ b/assets/js/portal.js
@@ -165,6 +165,7 @@
         (DOM.communityBtn.onclick = (e) => {
           e.preventDefault();
           dismissSplash();
+          window.location.href = "community.html";
         });
       DOM.publicBtn &&
         (DOM.publicBtn.onclick = (e) => {

--- a/community.html
+++ b/community.html
@@ -1,0 +1,548 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Community — CharlestonHacks</title>
+  <meta name="description" content="Join CharlestonHacks — Charleston's community for builders, hackers, and makers. Subscribe to our newsletter, find upcoming events, and connect with local innovators.">
+  <meta property="og:title" content="Join the CharlestonHacks Community">
+  <meta property="og:description" content="Charleston's hub for builders, hackers, and makers. Events, newsletter, and connection.">
+  <meta property="og:image" content="https://charlestonhacks.com/images/websitepanel.webp">
+  <meta property="og:url" content="https://charlestonhacks.com/community.html">
+  <link rel="canonical" href="https://charlestonhacks.com/community.html">
+  <link rel="icon" href="favicon.ico" type="image/x-icon">
+  <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
+  <link rel="manifest" href="/manifest.json">
+
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="styles.css">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-6NDKG07DY6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    gtag("js", new Date());
+    gtag("config", "G-6NDKG07DY6");
+  </script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      min-height: 100vh;
+      background: #000;
+      color: #fff;
+      font-family: 'Orbitron', 'Britannic Bold', Arial, sans-serif;
+    }
+
+    /* ── Nav ── */
+    .top-nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 24px;
+      border-bottom: 1px solid rgba(0,224,255,0.12);
+      position: sticky;
+      top: 0;
+      background: rgba(0,0,0,0.92);
+      backdrop-filter: blur(8px);
+      z-index: 100;
+    }
+    .top-nav a {
+      color: rgba(255,255,255,0.7);
+      text-decoration: none;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      transition: color 0.2s;
+    }
+    .top-nav a:hover { color: #00e0ff; }
+    .top-nav .logo-link img { width: 140px; height: auto; display: block; }
+
+    /* ── Hero ── */
+    .hero {
+      text-align: center;
+      padding: 72px 20px 48px;
+      background: radial-gradient(ellipse at 50% 0%, rgba(0,224,255,0.08) 0%, transparent 65%);
+    }
+    .hero-eyebrow {
+      display: inline-block;
+      background: rgba(0,224,255,0.1);
+      border: 1px solid rgba(0,224,255,0.3);
+      color: #00e0ff;
+      font-size: 0.65rem;
+      letter-spacing: 0.18em;
+      padding: 5px 14px;
+      border-radius: 999px;
+      margin-bottom: 20px;
+      text-transform: uppercase;
+    }
+    .hero h1 {
+      font-size: clamp(2rem, 6vw, 3.6rem);
+      font-weight: 900;
+      line-height: 1.1;
+      letter-spacing: -0.01em;
+      background: linear-gradient(135deg, #fff 30%, #00e0ff 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 20px;
+    }
+    .hero p {
+      max-width: 560px;
+      margin: 0 auto 40px;
+      color: rgba(255,255,255,0.6);
+      font-size: clamp(0.85rem, 2.2vw, 1rem);
+      line-height: 1.7;
+      font-family: Arial, sans-serif;
+    }
+    .hero-cta {
+      display: flex;
+      gap: 14px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .btn-primary {
+      background: linear-gradient(135deg, #00e0ff, #0099cc);
+      color: #000;
+      font-family: inherit;
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      padding: 13px 28px;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    .btn-primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 24px rgba(0,224,255,0.35);
+    }
+    .btn-outline {
+      background: transparent;
+      color: #fff;
+      font-family: inherit;
+      font-size: 0.8rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      padding: 12px 24px;
+      border: 1px solid rgba(255,255,255,0.25);
+      border-radius: 8px;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      transition: border-color 0.2s, color 0.2s, transform 0.2s;
+    }
+    .btn-outline:hover {
+      border-color: #00e0ff;
+      color: #00e0ff;
+      transform: translateY(-2px);
+    }
+
+    /* ── Stats ── */
+    .stats-bar {
+      display: flex;
+      justify-content: center;
+      gap: 0;
+      border-top: 1px solid rgba(255,255,255,0.07);
+      border-bottom: 1px solid rgba(255,255,255,0.07);
+      background: rgba(255,255,255,0.02);
+      flex-wrap: wrap;
+    }
+    .stat-item {
+      padding: 24px 40px;
+      text-align: center;
+      border-right: 1px solid rgba(255,255,255,0.07);
+      flex: 1;
+      min-width: 140px;
+    }
+    .stat-item:last-child { border-right: none; }
+    .stat-num {
+      font-size: clamp(1.6rem, 4vw, 2.4rem);
+      font-weight: 900;
+      color: #00e0ff;
+      display: block;
+    }
+    .stat-label {
+      font-size: 0.65rem;
+      color: rgba(255,255,255,0.45);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-top: 4px;
+    }
+
+    /* ── Section wrapper ── */
+    .section {
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 64px 20px;
+    }
+    .section-title {
+      font-size: clamp(1.2rem, 3vw, 1.7rem);
+      font-weight: 800;
+      letter-spacing: 0.04em;
+      margin-bottom: 8px;
+    }
+    .section-sub {
+      color: rgba(255,255,255,0.5);
+      font-size: 0.85rem;
+      font-family: Arial, sans-serif;
+      margin-bottom: 36px;
+      line-height: 1.6;
+    }
+
+    /* ── Action cards ── */
+    .action-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 20px;
+    }
+    .action-card {
+      background: #0d0d0d;
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 14px;
+      padding: 28px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      transition: border-color 0.25s, transform 0.25s, box-shadow 0.25s;
+      text-decoration: none;
+      color: inherit;
+    }
+    .action-card:hover {
+      border-color: rgba(0,224,255,0.4);
+      transform: translateY(-3px);
+      box-shadow: 0 8px 32px rgba(0,224,255,0.1);
+    }
+    .action-card.gold:hover {
+      border-color: rgba(201,163,94,0.5);
+      box-shadow: 0 8px 32px rgba(201,163,94,0.12);
+    }
+    .action-icon {
+      width: 44px;
+      height: 44px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.2rem;
+      background: rgba(0,224,255,0.1);
+      color: #00e0ff;
+    }
+    .action-icon.gold {
+      background: rgba(201,163,94,0.12);
+      color: #c9a35e;
+    }
+    .action-icon.green {
+      background: rgba(0,255,136,0.1);
+      color: #00ff88;
+    }
+    .action-card h3 {
+      font-size: 1rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+    }
+    .action-card p {
+      color: rgba(255,255,255,0.5);
+      font-size: 0.82rem;
+      line-height: 1.6;
+      font-family: Arial, sans-serif;
+      flex: 1;
+    }
+    .action-card .card-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.75rem;
+      color: #00e0ff;
+      letter-spacing: 0.06em;
+      margin-top: 4px;
+    }
+    .action-card.gold .card-link { color: #c9a35e; }
+    .action-card.green .card-link { color: #00ff88; }
+
+    /* ── Pillars ── */
+    .pillars-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+    }
+    .pillar {
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.07);
+      border-radius: 12px;
+      padding: 22px 18px;
+      text-align: center;
+    }
+    .pillar i {
+      font-size: 1.5rem;
+      color: #00e0ff;
+      margin-bottom: 12px;
+      display: block;
+    }
+    .pillar h4 {
+      font-size: 0.85rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      margin-bottom: 8px;
+    }
+    .pillar p {
+      color: rgba(255,255,255,0.45);
+      font-size: 0.75rem;
+      font-family: Arial, sans-serif;
+      line-height: 1.5;
+    }
+
+    /* ── Channels ── */
+    .channels-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+      gap: 14px;
+    }
+    .channel-btn {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 18px;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      color: #fff;
+      text-decoration: none;
+      font-size: 0.78rem;
+      letter-spacing: 0.05em;
+      transition: background 0.2s, border-color 0.2s, color 0.2s;
+    }
+    .channel-btn:hover {
+      background: rgba(0,224,255,0.06);
+      border-color: rgba(0,224,255,0.3);
+      color: #00e0ff;
+    }
+    .channel-btn i { font-size: 1.1rem; width: 20px; text-align: center; }
+
+    /* ── Newsletter inline ── */
+    .newsletter-box {
+      background: linear-gradient(135deg, rgba(0,224,255,0.06) 0%, rgba(0,0,0,0) 100%);
+      border: 1px solid rgba(0,224,255,0.2);
+      border-radius: 16px;
+      padding: 40px 32px;
+      text-align: center;
+    }
+    .newsletter-box h2 {
+      font-size: clamp(1.1rem, 3vw, 1.5rem);
+      margin-bottom: 10px;
+    }
+    .newsletter-box p {
+      color: rgba(255,255,255,0.55);
+      font-family: Arial, sans-serif;
+      font-size: 0.88rem;
+      margin-bottom: 24px;
+      line-height: 1.6;
+    }
+
+    /* ── Divider ── */
+    .divider {
+      border: none;
+      border-top: 1px solid rgba(255,255,255,0.07);
+    }
+
+    /* ── Footer ── */
+    footer {
+      text-align: center;
+      padding: 32px 20px 48px;
+      color: rgba(255,255,255,0.25);
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      border-top: 1px solid rgba(255,255,255,0.07);
+    }
+    footer a { color: rgba(255,255,255,0.35); text-decoration: none; }
+    footer a:hover { color: #00e0ff; }
+
+    @media (max-width: 600px) {
+      .stat-item { padding: 18px 20px; }
+      .section { padding: 48px 16px; }
+      .newsletter-box { padding: 28px 18px; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Nav -->
+  <nav class="top-nav">
+    <a href="index.html" class="logo-link" aria-label="CharlestonHacks home">
+      <img src="images/charlestonhackslogo.svg" alt="CharlestonHacks">
+    </a>
+    <a href="index.html"><i class="fas fa-home" style="margin-right:6px;"></i>Home</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <span class="hero-eyebrow">Charleston, SC</span>
+    <h1>Build. Connect.<br>Hack.</h1>
+    <p>CharlestonHacks is the local hub for builders, tinkerers, and innovators. Whether you're shipping your first project or your fiftieth, there's a seat for you here.</p>
+    <div class="hero-cta">
+      <a href="subscribe.html" class="btn-primary">
+        <i class="fas fa-envelope-open-text"></i> Join the Mailing List
+      </a>
+      <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" class="btn-outline">
+        <i class="fas fa-calendar-alt"></i> Find Events
+      </a>
+    </div>
+  </section>
+
+  <!-- Stats -->
+  <div class="stats-bar" role="list">
+    <div class="stat-item" role="listitem">
+      <span class="stat-num">10+</span>
+      <span class="stat-label">Events Hosted</span>
+    </div>
+    <div class="stat-item" role="listitem">
+      <span class="stat-num">500+</span>
+      <span class="stat-label">Community Members</span>
+    </div>
+    <div class="stat-item" role="listitem">
+      <span class="stat-num">5+</span>
+      <span class="stat-label">Years Active</span>
+    </div>
+    <div class="stat-item" role="listitem">
+      <span class="stat-num">∞</span>
+      <span class="stat-label">Ideas Built</span>
+    </div>
+  </div>
+
+  <!-- Primary Actions -->
+  <div class="section">
+    <p class="section-title">Get Involved</p>
+    <p class="section-sub">Three ways to plug in — pick whichever fits you right now.</p>
+
+    <div class="action-grid">
+      <a href="subscribe.html" class="action-card">
+        <div class="action-icon"><i class="fas fa-paper-plane"></i></div>
+        <h3>Join the Mailing List</h3>
+        <p>Stay in the loop on upcoming hackathons, workshops, and community news. Low-volume, high-signal.</p>
+        <span class="card-link">Subscribe <i class="fas fa-arrow-right"></i></span>
+      </a>
+
+      <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" class="action-card">
+        <div class="action-icon"><i class="fas fa-calendar-check"></i></div>
+        <h3>Find Upcoming Events</h3>
+        <p>Hackathons, show &amp; tells, lightning talks, and more. See what's happening on Meetup.com.</p>
+        <span class="card-link">View Events <i class="fas fa-arrow-right"></i></span>
+      </a>
+
+      <a href="https://deckerd451.github.io/innovation-engine/" class="action-card">
+        <div class="action-icon"><i class="fas fa-people-arrows"></i></div>
+        <h3>Innovation Engine</h3>
+        <p>Connect directly with members, discover projects, and explore the community network.</p>
+        <span class="card-link">Open Dashboard <i class="fas fa-arrow-right"></i></span>
+      </a>
+
+      <a href="donations.html" class="action-card gold">
+        <div class="action-icon gold"><i class="fas fa-heart"></i></div>
+        <h3>Support the Community</h3>
+        <p>Help us keep events free and accessible. Donate, sponsor, or become a GitHub supporter.</p>
+        <span class="card-link">Support Us <i class="fas fa-arrow-right"></i></span>
+      </a>
+    </div>
+  </div>
+
+  <hr class="divider">
+
+  <!-- What we do -->
+  <div class="section">
+    <p class="section-title">What We Do</p>
+    <p class="section-sub">We make the invisible networks of Charleston's tech scene visible.</p>
+
+    <div class="pillars-grid">
+      <div class="pillar">
+        <i class="fas fa-code"></i>
+        <h4>Hackathons</h4>
+        <p>48-hour sprints where ideas become real products — all skill levels welcome.</p>
+      </div>
+      <div class="pillar">
+        <i class="fas fa-lightbulb"></i>
+        <h4>Show &amp; Tell</h4>
+        <p>Present what you've been building to an engaged, supportive crowd.</p>
+      </div>
+      <div class="pillar">
+        <i class="fas fa-network-wired"></i>
+        <h4>Networking</h4>
+        <p>Meet founders, engineers, designers, and makers living and working in Charleston.</p>
+      </div>
+      <div class="pillar">
+        <i class="fas fa-flask"></i>
+        <h4>Experiments</h4>
+        <p>Open sandbox sessions for new tech, demos, and building weird things together.</p>
+      </div>
+      <div class="pillar">
+        <i class="fas fa-trophy"></i>
+        <h4>Competitions</h4>
+        <p>Regional and national hackathon teams powered by local talent.</p>
+      </div>
+      <div class="pillar">
+        <i class="fas fa-hand-holding-heart"></i>
+        <h4>Open Access</h4>
+        <p>Free events, shared resources, and zero gatekeeping — community first.</p>
+      </div>
+    </div>
+  </div>
+
+  <hr class="divider">
+
+  <!-- Connect channels -->
+  <div class="section">
+    <p class="section-title">Connect With Us</p>
+    <p class="section-sub">Find the channel that works for you.</p>
+
+    <div class="channels-grid">
+      <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" class="channel-btn">
+        <i class="fas fa-users" style="color:#f65858;"></i> Meetup
+      </a>
+      <a href="https://www.instagram.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" class="channel-btn">
+        <i class="fab fa-instagram" style="color:#e1306c;"></i> Instagram
+      </a>
+      <a href="https://www.linkedin.com/company/charlestonhacks" target="_blank" rel="noopener noreferrer" class="channel-btn">
+        <i class="fab fa-linkedin" style="color:#0a66c2;"></i> LinkedIn
+      </a>
+      <a href="https://www.facebook.com/charlestonhacks" target="_blank" rel="noopener noreferrer" class="channel-btn">
+        <i class="fab fa-facebook" style="color:#1877f2;"></i> Facebook
+      </a>
+      <a href="https://github.com/charlestonhacks" target="_blank" rel="noopener noreferrer" class="channel-btn">
+        <i class="fab fa-github" style="color:#ccc;"></i> GitHub
+      </a>
+      <a href="mailto:hello@charlestonhacks.com" class="channel-btn">
+        <i class="fas fa-envelope" style="color:#c9a35e;"></i> Email Us
+      </a>
+    </div>
+  </div>
+
+  <hr class="divider">
+
+  <!-- Newsletter CTA -->
+  <div class="section" style="padding-top:48px;padding-bottom:72px;">
+    <div class="newsletter-box">
+      <h2>Stay in the Loop</h2>
+      <p>Get notified about hackathons, show &amp; tells, and local tech events.<br>No spam — just the good stuff.</p>
+      <a href="subscribe.html" class="btn-primary">
+        <i class="fas fa-envelope-open-text"></i> Subscribe to the Newsletter
+      </a>
+    </div>
+  </div>
+
+  <footer>
+    <p>© 2026 CharlestonHacks · Charleston, SC ·
+      <a href="index.html">Home</a> ·
+      <a href="mailto:hello@charlestonhacks.com">hello@charlestonhacks.com</a>
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
       <a href="https://github.com/sponsors/deckerd451" target="_blank" title="Sponsor on GitHub" aria-label="Sponsor on GitHub">
         <i class="fas fa-heart"></i>
       </a>
-      <a href="https://deckerd451.github.io/innovation-engine/" title="Community Hub" aria-label="Community Hub">
+      <a href="community.html" title="Join the Community" aria-label="Join the Community">
         <i class="fas fa-people-arrows"></i>
       </a>
       <a href="subscribe.html" title="Newsletter Signup" aria-label="Newsletter Signup">


### PR DESCRIPTION
- community.html: new hub page with hero, stats bar, four action cards (newsletter, events, Innovation Engine, donations), six community pillars, social channel links, and an inline newsletter CTA footer
- index.html: icon-bar people-arrows link now routes to community.html instead of directly to the Innovation Engine
- portal.js: splash screen "Community Dashboard" button navigates to community.html (was a no-op dismiss)

https://claude.ai/code/session_01GNPvASqc3rGGEG9MXgCt1L