### PR TITLE
Fix four flow issues identified in UX review

### DIFF
--- a/assets/js/portal.js
+++ b/assets/js/portal.js
@@ -171,7 +171,7 @@
         (DOM.publicBtn.onclick = (e) => {
           e.preventDefault();
           dismissSplash();
-          window.location.href = "https://charlestonhacks.mailchimpsites.com/";
+          window.location.href = "news.html";
         });
     }
 

--- a/community.html
+++ b/community.html
@@ -421,7 +421,7 @@
   <!-- Primary Actions -->
   <div class="section">
     <p class="section-title">Get Involved</p>
-    <p class="section-sub">Three ways to plug in — pick whichever fits you right now.</p>
+    <p class="section-sub">Pick whichever fits you right now.</p>
 
     <div class="action-grid">
       <a href="subscribe.html" class="action-card">

--- a/index.html
+++ b/index.html
@@ -195,13 +195,13 @@
 
       <div style="display:flex;flex-direction:column;gap:.75rem;">
         <button id="community-site-btn" class="btn">
-          Community Dashboard
-          <span style="display:block;font-size:.75rem;opacity:.7;font-weight:normal;margin-top:.2rem;">Connect with members · Innovation Engine</span>
+          Community Hub
+          <span style="display:block;font-size:.75rem;opacity:.7;font-weight:normal;margin-top:.2rem;">Events · Newsletter · Connect</span>
         </button>
         <button id="public-site-btn" class="btn"
           style="background:transparent;border:2px solid var(--cyan);color:var(--cyan);">
-          Public Website
-          <span style="display:block;font-size:.75rem;opacity:.7;font-weight:normal;margin-top:.2rem;">News, newsletter &amp; announcements</span>
+          News &amp; Updates
+          <span style="display:block;font-size:.75rem;opacity:.7;font-weight:normal;margin-top:.2rem;">Latest announcements &amp; event recaps</span>
         </button>
       </div>
 

--- a/subscribe.html
+++ b/subscribe.html
@@ -173,6 +173,38 @@
                 padding: 1.25rem;
             }
         }
+
+        #subscribe-success {
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            gap: 16px;
+            padding: 40px 20px;
+            text-align: center;
+        }
+        #subscribe-success .success-icon {
+            font-size: 3rem;
+            color: #00e0ff;
+        }
+        #subscribe-success h3 {
+            color: #c9a35e;
+            font-size: 1.4rem;
+            margin: 0;
+        }
+        #subscribe-success p {
+            color: #aaa;
+            font-size: .9rem;
+            line-height: 1.6;
+            margin: 0;
+        }
+        #subscribe-success a {
+            display: inline-block;
+            margin-top: 8px;
+            color: #00e0ff;
+            font-size: .85rem;
+            text-decoration: none;
+        }
+        #subscribe-success a:hover { text-decoration: underline; }
     </style>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
@@ -200,6 +232,11 @@
                     return;
                 }
                 captchaError.style.display = 'none';
+                // Show success panel immediately — Mailchimp confirmation opens in new tab
+                setTimeout(function() {
+                    document.getElementById('mc_embed_signup_scroll').style.display = 'none';
+                    document.getElementById('subscribe-success').style.display = 'flex';
+                }, 100);
             });
 
             captchaInput.addEventListener('input', function() {
@@ -280,6 +317,12 @@
                     </div>
                 </div>
             </form>
+        <div id="subscribe-success">
+            <i class="fas fa-check-circle success-icon"></i>
+            <h3>You're in!</h3>
+            <p>Thanks for subscribing. Check your inbox for a confirmation email — then you're all set for event updates and community news.</p>
+            <a href="community.html"><i class="fas fa-arrow-left" style="margin-right:6px;"></i>Back to Community</a>
+        </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
- index.html: splash "Community Dashboard" relabeled to "Community Hub" with updated subtitle; "Public Website" relabeled to "News & Updates"
- portal.js: "News & Updates" splash button routes to news.html instead of the external Mailchimp-hosted page
- subscribe.html: after a valid submission the form hides and an inline success panel appears so users get immediate feedback (Mailchimp confirmation still opens in a new tab); success panel links back to community.html
- community.html: removed the inaccurate "three ways to plug in" copy that didn't match the four action cards

https://claude.ai/code/session_01GNPvASqc3rGGEG9MXgCt1L