### PR TITLE
Replace broken events modal with direct Meetup link

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@
       <a href="https://www.facebook.com/charlestonhacks" target="_blank" title="Facebook" aria-label="Facebook">
         <i class="fab fa-facebook"></i>
       </a>
-      <a id="open-calendar" title="Charleston Events Calendar" aria-label="Events Calendar" style="cursor:pointer;">
+      <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" title="Charleston Events on Meetup" aria-label="Events Calendar">
         <i class="fas fa-calendar-alt"></i>
       </a>
     </section>


### PR DESCRIPTION
Calendar icon in the icon bar now links to meetup.com/charlestonhacks instead of triggering the worker-powered modal that showed no results.

https://claude.ai/code/session_01GNPvASqc3rGGEG9MXgCt1L