### PR TITLE
Fix Zork: replace fake ZVM stub with real zmachine@0.3.0 Z-machine en…

### DIFF
--- a/assets/js/zorkLoader.js
+++ b/assets/js/zorkLoader.js
@@ -1,40 +1,139 @@
-// zorkLoader.js – simplified loader with save/restore support
-import { ZVM } from "./zvm.js";
+// zorkLoader.js – real Z-machine using zmachine@0.3.0
 
-let zork = null;
+const ZM_ESM = 'https://cdn.jsdelivr.net/npm/zmachine@0.3.0/dist/zmachine.esm.min.js';
+const STORY_PATH = '/assets/zork/zork1.z3';
+
+let zm = null;
+let lineResolve = null;
+let charResolve = null;
+
+class BbsIOAdapter {
+  constructor(writeFn) {
+    this._write = writeFn;
+    this._buf = '';
+  }
+
+  _flush() {
+    if (!this._buf) return;
+    this._write(this._buf);
+    this._buf = '';
+  }
+
+  initialize() {}
+
+  print(text) {
+    this._buf += text;
+    if (this._buf.includes('\n')) this._flush();
+  }
+
+  printLine(text) {
+    this._buf += (text || '') + '\n';
+    this._flush();
+  }
+
+  newLine() {
+    this._buf += '\n';
+    this._flush();
+  }
+
+  readLine(maxLength = 78) {
+    this._flush();
+    return new Promise(resolve => { lineResolve = resolve; });
+  }
+
+  readChar() {
+    this._flush();
+    return new Promise(resolve => { charResolve = resolve; });
+  }
+
+  quit() {
+    this._flush();
+    this._write('\n[ZORK ended — type zork to start over]\n');
+    zm = null;
+    lineResolve = null;
+    charResolve = null;
+  }
+
+  restart() {
+    this._flush();
+    this._write('\n[ZORK restarted]\n');
+  }
+
+  // Optional stubs to satisfy the interface
+  setWindow() {}
+  splitWindow() {}
+  eraseWindow() {}
+  showStatusLine() {}
+  setTextStyle() {}
+  setBufferMode() {}
+  getBufferMode() { return true; }
+  verify() { return true; }
+}
 
 export async function startZork(write) {
-  if (!zork) {
-    const story = await fetch("./zork1.z3").then(r => r.arrayBuffer());
-    zork = new ZVM(new Uint8Array(story));
-    zork.start();
+  if (zm) {
+    write('[ZORK already running — type /exit to leave]\n');
+    return;
   }
-  write(zork.readStoryOutput());
+
+  write('Loading ZORK I…\n');
+
+  let ZMachine;
+  try {
+    ({ ZMachine } = await import(ZM_ESM));
+  } catch (err) {
+    write(`[Failed to load Z-machine engine: ${err.message}]\n`);
+    return;
+  }
+
+  let storyBuffer;
+  try {
+    storyBuffer = await fetch(STORY_PATH).then(r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r.arrayBuffer();
+    });
+  } catch (err) {
+    write(`[Failed to fetch story file: ${err.message}]\n`);
+    return;
+  }
+
+  const io = new BbsIOAdapter(write);
+
+  try {
+    zm = ZMachine.load(storyBuffer, io);
+  } catch (err) {
+    write(`[Failed to initialize Z-machine: ${err.message}]\n`);
+    zm = null;
+    return;
+  }
+
+  zm.run().catch(err => {
+    write(`[ZORK error: ${err.message}]\n`);
+    zm = null;
+    lineResolve = null;
+    charResolve = null;
+  });
 }
 
 export function sendZorkCommand(cmd, write) {
-  if (!zork) return;
-  zork.sendCommand(cmd);
-  write(zork.readStoryOutput());
-}
-
-// Serialize interpreter state (memory, instruction pointer, finished flag)
-export function getZorkState() {
-  if (!zork) return null;
-  return {
-    memory: Array.from(zork.memory),
-    ip: zork.ip,
-    finished: zork.finished
-  };
-}
-
-// Restore interpreter state
-export function setZorkState(state) {
-  if (!state) return;
-  if (!zork) {
-    zork = new ZVM(new Uint8Array(state.memory));
+  if (!zm) {
+    write('[No ZORK session active]\n');
+    return;
   }
-  zork.memory = new Uint8Array(state.memory);
-  zork.ip = state.ip;
-  zork.finished = state.finished;
+  if (lineResolve) {
+    const resolve = lineResolve;
+    lineResolve = null;
+    resolve({ text: cmd, terminator: 13 });
+  } else if (charResolve) {
+    const resolve = charResolve;
+    charResolve = null;
+    resolve(cmd.charCodeAt(0) || 13);
+  }
 }
+
+// Save/restore stubs — kept for API compatibility with bbs.js
+export function getZorkState() {
+  return null;
+}
+
+export function setZorkState() {}


### PR DESCRIPTION
…gine

The previous zorkLoader.js used a hand-rolled fake that only recognized 7 hardcoded commands. This replaces it with a real Z-machine interpreter (zmachine@0.3.0 from jsDelivr CDN) that actually executes the zork1.z3 story file bytecode.

- BbsIOAdapter bridges the zmachine IOAdapter interface to the BBS write() callback, buffering incremental output and flushing on newlines
- Async input (readLine/readChar) is wired via a stored Promise resolver that sendZorkCommand() resolves when the user submits a command
- Corrected story file path from ./zork1.z3 → /assets/zork/zork1.z3
- getZorkState/setZorkState stubbed for API compat (Quetzal save/restore can be added later via the zmachine save/restore IOAdapter methods)

https://claude.ai/code/session_01GNPvASqc3rGGEG9MXgCt1L