### PR TITLE
Make "What We Do" pillars clickable links to hub features

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,6 +281,18 @@
       border-radius: 12px;
       padding: 22px 18px;
       text-align: center;
+      text-decoration: none;
+      color: inherit;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      transition: background 0.2s, border-color 0.2s, transform 0.2s;
+      cursor: pointer;
+    }
+    .pillar:hover {
+      background: rgba(0,224,255,0.06);
+      border-color: rgba(0,224,255,0.35);
+      transform: translateY(-2px);
     }
     .pillar i {
       font-size: 1.5rem;
@@ -299,6 +311,18 @@
       font-size: 0.75rem;
       font-family: Arial, sans-serif;
       line-height: 1.5;
+      flex: 1;
+    }
+    .pillar .pillar-cta {
+      margin-top: 12px;
+      font-size: 0.7rem;
+      color: #00e0ff;
+      letter-spacing: 0.06em;
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+    .pillar:hover .pillar-cta {
+      opacity: 1;
     }
 
     /* ── Channels ── */
@@ -479,36 +503,42 @@
     <p class="section-sub">We make the invisible networks of Charleston's tech scene visible.</p>
 
     <div class="pillars-grid">
-      <div class="pillar">
+      <a class="pillar" href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer">
         <i class="fas fa-code"></i>
         <h4>Hackathons</h4>
         <p>48-hour sprints where ideas become real products — all skill levels welcome.</p>
-      </div>
-      <div class="pillar">
+        <span class="pillar-cta">View Events →</span>
+      </a>
+      <a class="pillar" href="showandtell2.html">
         <i class="fas fa-lightbulb"></i>
         <h4>Show &amp; Tell</h4>
         <p>Present what you've been building to an engaged, supportive crowd.</p>
-      </div>
-      <div class="pillar">
+        <span class="pillar-cta">See Highlights →</span>
+      </a>
+      <a class="pillar" href="community.html">
         <i class="fas fa-network-wired"></i>
         <h4>Networking</h4>
         <p>Meet founders, engineers, designers, and makers living and working in Charleston.</p>
-      </div>
-      <div class="pillar">
+        <span class="pillar-cta">Join the Community →</span>
+      </a>
+      <a class="pillar" href="experimental.html">
         <i class="fas fa-flask"></i>
         <h4>Experiments</h4>
         <p>Open sandbox sessions for new tech, demos, and building weird things together.</p>
-      </div>
-      <div class="pillar">
+        <span class="pillar-cta">Explore Sandbox →</span>
+      </a>
+      <a class="pillar" href="harborhack24.html">
         <i class="fas fa-trophy"></i>
         <h4>Competitions</h4>
         <p>Regional and national hackathon teams powered by local talent.</p>
-      </div>
-      <div class="pillar">
+        <span class="pillar-cta">View Competitions →</span>
+      </a>
+      <a class="pillar" href="subscribe.html">
         <i class="fas fa-hand-holding-heart"></i>
         <h4>Open Access</h4>
         <p>Free events, shared resources, and zero gatekeeping — community first.</p>
-      </div>
+        <span class="pillar-cta">Stay in the Loop →</span>
+      </a>
     </div>
   </div>
 


### PR DESCRIPTION
Each pillar card in the homepage "What We Do" section is now an anchor that routes to the relevant member hub page. Hover reveals a contextual CTA label and a subtle cyan lift effect signals interactivity.

- Hackathons → Meetup events page
- Show & Tell → showandtell2.html
- Networking → community.html
- Experiments → experimental.html
- Competitions → harborhack24.html
- Open Access → subscribe.html

https://claude.ai/code/session_01BPy2MrYxsMSqhRbzstjgDD