### PR TITLE
Merge Competitions into Hackathons, update Networking link

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,11 +503,11 @@
     <p class="section-sub">We make the invisible networks of Charleston's tech scene visible.</p>
 
     <div class="pillars-grid">
-      <a class="pillar" href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer">
+      <a class="pillar" href="harborhack24.html">
         <i class="fas fa-code"></i>
         <h4>Hackathons</h4>
         <p>48-hour sprints where ideas become real products — all skill levels welcome.</p>
-        <span class="pillar-cta">View Events →</span>
+        <span class="pillar-cta">View Hackathons →</span>
       </a>
       <a class="pillar" href="showandtell2.html">
         <i class="fas fa-lightbulb"></i>
@@ -515,7 +515,7 @@
         <p>Present what you've been building to an engaged, supportive crowd.</p>
         <span class="pillar-cta">See Highlights →</span>
       </a>
-      <a class="pillar" href="community.html">
+      <a class="pillar" href="https://charlestonhacks.mailchimpsites.com/" target="_blank" rel="noopener noreferrer">
         <i class="fas fa-network-wired"></i>
         <h4>Networking</h4>
         <p>Meet founders, engineers, designers, and makers living and working in Charleston.</p>
@@ -526,12 +526,6 @@
         <h4>Experiments</h4>
         <p>Open sandbox sessions for new tech, demos, and building weird things together.</p>
         <span class="pillar-cta">Explore Sandbox →</span>
-      </a>
-      <a class="pillar" href="harborhack24.html">
-        <i class="fas fa-trophy"></i>
-        <h4>Competitions</h4>
-        <p>Regional and national hackathon teams powered by local talent.</p>
-        <span class="pillar-cta">View Competitions →</span>
       </a>
       <a class="pillar" href="subscribe.html">
         <i class="fas fa-hand-holding-heart"></i>


### PR DESCRIPTION
- Hackathons now links to harborhack24.html (absorbed Competitions card)
- Networking now opens charlestonhacks.mailchimpsites.com in a new tab
- Competitions card removed (down from 6 to 5 pillars)

https://claude.ai/code/session_01BPy2MrYxsMSqhRbzstjgDD