### PR TITLE
Restructure homepage sections: Get Involved + Who We Are

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,61 +449,8 @@
     <p class="section-title">Get Involved</p>
     <p class="section-sub">Pick whichever fits you right now.</p>
 
-    <div class="action-grid">
-      <a href="subscribe.html" class="action-card">
-        <div class="action-icon"><i class="fas fa-paper-plane"></i></div>
-        <h3>Join the Mailing List</h3>
-        <p>Stay in the loop on upcoming hackathons, workshops, and community news. Low-volume, high-signal.</p>
-        <span class="card-link">Subscribe <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-      <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" class="action-card">
-        <div class="action-icon"><i class="fas fa-calendar-check"></i></div>
-        <h3>Find Upcoming Events</h3>
-        <p>Hackathons, show &amp; tells, lightning talks, and more. See what's happening on Meetup.com.</p>
-        <span class="card-link">View Events <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-      <a href="https://deckerd451.github.io/innovation-engine/" class="action-card">
-        <div class="action-icon"><i class="fas fa-people-arrows"></i></div>
-        <h3>Innovation Engine</h3>
-        <p>Connect directly with members, discover projects, and explore the community network.</p>
-        <span class="card-link">Open Dashboard <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-
-      <a href="/hub.html" class="action-card">
-        <div class="action-icon"><i class="fas fa-th-large"></i></div>
-        <h3>Already part of CharlestonHacks?</h3>
-        <p>Returning member? Jump straight into the interactive portal for tools, channels, and experiments.</p>
-        <span class="card-link">Explore the Member Hub <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-      <a href="donations.html" class="action-card gold">
-        <div class="action-icon gold"><i class="fas fa-heart"></i></div>
-        <h3>Support the Community</h3>
-        <p>Help us keep events free and accessible. Donate, sponsor, or become a GitHub supporter.</p>
-        <span class="card-link">Support Us <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-      <a href="bbs.html" class="action-card">
-        <div class="action-icon" style="background:rgba(0,255,0,0.08);color:#0f0;"><i class="fas fa-terminal"></i></div>
-        <h3>Community BBS</h3>
-        <p>Real-time community chat with a retro terminal vibe. Members only area — type <code style="color:#0f0;font-size:.78rem;">zork</code> for a surprise.</p>
-        <span class="card-link" style="color:#0f0;">Open Terminal <i class="fas fa-arrow-right"></i></span>
-      </a>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- What we do -->
-  <div class="section">
-    <p class="section-title">What We Do</p>
-    <p class="section-sub">We make the invisible networks of Charleston's tech scene visible.</p>
-
     <div class="pillars-grid">
-      <a class="pillar" href="harborhack24.html">
+      <a class="pillar" href="https://charlestonhacks.com/Poster.html">
         <i class="fas fa-code"></i>
         <h4>Hackathons</h4>
         <p>48-hour sprints where ideas become real products — all skill levels welcome.</p>
@@ -515,12 +462,6 @@
         <p>Present what you've been building to an engaged, supportive crowd.</p>
         <span class="pillar-cta">See Highlights →</span>
       </a>
-      <a class="pillar" href="https://charlestonhacks.mailchimpsites.com/" target="_blank" rel="noopener noreferrer">
-        <i class="fas fa-network-wired"></i>
-        <h4>Networking</h4>
-        <p>Meet founders, engineers, designers, and makers living and working in Charleston.</p>
-        <span class="pillar-cta">Join the Community →</span>
-      </a>
       <a class="pillar" href="experimental.html">
         <i class="fas fa-flask"></i>
         <h4>Experiments</h4>
@@ -528,10 +469,57 @@
         <span class="pillar-cta">Explore Sandbox →</span>
       </a>
       <a class="pillar" href="subscribe.html">
-        <i class="fas fa-hand-holding-heart"></i>
-        <h4>Open Access</h4>
-        <p>Free events, shared resources, and zero gatekeeping — community first.</p>
-        <span class="pillar-cta">Stay in the Loop →</span>
+        <i class="fas fa-paper-plane"></i>
+        <h4>Join the Mailing List</h4>
+        <p>Stay in the loop on upcoming hackathons, workshops, and community news. Low-volume, high-signal.</p>
+        <span class="pillar-cta">Subscribe →</span>
+      </a>
+      <a class="pillar" href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer">
+        <i class="fas fa-calendar-check"></i>
+        <h4>Find Upcoming Events</h4>
+        <p>Hackathons, show &amp; tells, lightning talks, and more. See what's happening on Meetup.com.</p>
+        <span class="pillar-cta">View Events →</span>
+      </a>
+      <a class="pillar" href="https://deckerd451.github.io/innovation-engine/" target="_blank" rel="noopener noreferrer">
+        <i class="fas fa-people-arrows"></i>
+        <h4>Networking</h4>
+        <p>Connect directly with members, discover projects, and explore the community network.</p>
+        <span class="pillar-cta">Open Dashboard →</span>
+      </a>
+      <a class="pillar" href="/hub.html">
+        <i class="fas fa-th-large"></i>
+        <h4>Member Hub</h4>
+        <p>Returning member? Jump straight into the interactive portal for tools, channels, and experiments.</p>
+        <span class="pillar-cta">Explore the Hub →</span>
+      </a>
+      <a class="pillar" href="donations.html">
+        <i class="fas fa-heart"></i>
+        <h4>Support the Community</h4>
+        <p>Help us keep events free and accessible. Donate, sponsor, or become a GitHub supporter.</p>
+        <span class="pillar-cta">Support Us →</span>
+      </a>
+      <a class="pillar" href="bbs.html">
+        <i class="fas fa-terminal"></i>
+        <h4>Community BBS</h4>
+        <p>Real-time community chat with a retro terminal vibe. Members only area.</p>
+        <span class="pillar-cta">Open Terminal →</span>
+      </a>
+    </div>
+  </div>
+
+  <hr class="divider">
+
+  <!-- Who We Are -->
+  <div class="section">
+    <p class="section-title">Who We Are</p>
+    <p class="section-sub">We make the invisible networks of Charleston's tech scene visible.</p>
+
+    <div class="pillars-grid">
+      <a class="pillar" href="https://charlestonhacks.mailchimpsites.com/" target="_blank" rel="noopener noreferrer">
+        <i class="fas fa-users"></i>
+        <h4>Meet the Community</h4>
+        <p>Meet founders, engineers, designers, and makers living and working in Charleston.</p>
+        <span class="pillar-cta">Join the Community →</span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
- Get Involved: merged all action-cards and What We Do pillars into a single unified pillars-grid; Hackathons links to Poster.html; Innovation Engine renamed to Networking; Open Access removed
- What We Do renamed to Who We Are with a single Meet the Community pillar linking to charlestonhacks.mailchimpsites.com

https://claude.ai/code/session_01BPy2MrYxsMSqhRbzstjgDD