### PR TITLE
Mobile responsiveness audit fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,24 +427,50 @@
     footer a:hover { color: #00e0ff; }
 
     @media (max-width: 600px) {
-      .top-nav a:not(.logo-link) { font-size: 0.8rem; }
-      .hero { padding: 48px 16px 36px; }
-      .hero-eyebrow { font-size: 0.72rem; }
-      .stat-item { padding: 18px 20px; }
-      .stat-label { font-size: 0.7rem; }
-      .section { padding: 40px 16px; }
+      /* Nav */
+      .top-nav { padding: 12px 16px; }
+      .top-nav a:not(.logo-link) { font-size: 0.78rem; }
+      .top-nav .logo-link img { width: 120px; }
+
+      /* Countdown */
+      #event-countdown-banner { white-space: normal; font-size: 0.65rem; padding: 6px 12px; }
+
+      /* Hero */
+      .hero { padding: 44px 16px 32px; }
+      .hero-eyebrow { font-size: 0.7rem; letter-spacing: 0.12em; }
+      .hero p { font-size: 0.95rem; }
+      .hero-cta { flex-direction: column; align-items: stretch; }
+      .btn-primary, .btn-outline { justify-content: center; font-size: 0.85rem; padding: 14px 20px; }
+
+      /* Stats — fix 2×2 grid border bleed + label wrapping */
+      .stat-item { padding: 16px 12px; min-width: 0; flex-basis: 50%; }
+      .stat-item:nth-child(2n) { border-right: none; }
+      .stat-item:nth-child(1),
+      .stat-item:nth-child(2) { border-bottom: 1px solid rgba(255,255,255,0.07); }
+      .stat-label { font-size: 0.68rem; letter-spacing: 0.04em; }
+
+      /* Sections */
+      .section { padding: 36px 16px; }
       .section-title { font-size: clamp(1.3rem, 5vw, 1.7rem); }
-      .section-sub { font-size: 0.92rem; }
-      .pillars-grid { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; }
-      .pillar { padding: 18px 14px; }
-      .pillar h4 { font-size: 0.88rem; }
-      .pillar p { font-size: 0.82rem; }
-      .pillar .pillar-cta { opacity: 1; font-size: 0.76rem; }
+      .section-sub { font-size: 0.9rem; }
+
+      /* Pillars */
+      .pillars-grid { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+      .pillar { padding: 16px 12px; }
+      .pillar h4 { font-size: 0.86rem; }
+      .pillar p { font-size: 0.8rem; }
+      .pillar .pillar-cta { opacity: 1; font-size: 0.74rem; }
+
+      /* Channels */
       .channels-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
-      .channel-btn { font-size: 0.82rem; }
-      .newsletter-box { padding: 28px 18px; }
+      .channel-btn { font-size: 0.82rem; padding: 12px 14px; }
+
+      /* Newsletter */
+      .newsletter-box { padding: 24px 16px; }
       .newsletter-box p { font-size: 0.9rem; }
-      footer { font-size: 0.72rem; }
+
+      /* Footer */
+      footer { font-size: 0.7rem; padding: 24px 16px 40px; }
     }
   </style>
 </head>
@@ -717,10 +743,12 @@
       els.forEach(el => observer.observe(el));
     })();
 
-    // ── VanillaTilt on pillar cards ──
-    VanillaTilt.init(document.querySelectorAll('.pillar'), {
-      max: 8, speed: 400, glare: true, 'max-glare': 0.08, scale: 1.02
-    });
+    // ── VanillaTilt on pillar cards (desktop/mouse only) ──
+    if (window.matchMedia('(hover: hover)').matches) {
+      VanillaTilt.init(document.querySelectorAll('.pillar'), {
+        max: 8, speed: 400, glare: true, 'max-glare': 0.08, scale: 1.02
+      });
+    }
 
     // ── Live event countdown ──
     (function () {


### PR DESCRIPTION
- Stats 2x2 grid: remove right border bleed on even items, add bottom border between rows, reduce letter-spacing so labels don't wrap
- Hero CTA: stack buttons full-width on mobile for better touch targets
- Hero paragraph: raise font floor to 0.95rem (was hitting clamp too low)
- Countdown banner: allow text to wrap on narrow screens instead of truncating
- Nav: tighten padding and logo width on mobile
- VanillaTilt: disabled on touch devices (hover:none) — no mouse, no tilt
- Pillar/channel/newsletter/footer: tighter padding and spacing throughout

https://claude.ai/code/session_01BPy2MrYxsMSqhRbzstjgDD