### PR TITLE
Fix latest event to show Happy Hour (Apr 21, 2026)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1023,14 +1023,14 @@
     <p class="section-sub" data-aos="fade-up" data-aos-delay="60">Here's what went down at our most recent gathering.</p>
 
     <div id="latest-event-card" data-aos="fade-up" data-aos-delay="120">
-      <!-- Populated by JS; fallback below if fetch fails -->
+      <!-- JS will overwrite if worker returns past events; otherwise this fallback shows -->
       <div class="recap-card">
-        <img class="recap-image" src="images/hnwinners.jpg" alt="Hack Nights 2024 — AI for Humanity winners" loading="lazy">
+        <img class="recap-image" src="images/goodpartyshot.jpg" alt="CharlestonHacks Happy Hour at Revelry Brewery" loading="lazy">
         <div class="recap-body">
-          <span class="recap-eyebrow">Hack Nights 2024</span>
-          <h3>AI for Humanity</h3>
-          <p>Teams tackled real-world challenges using generative AI across healthcare, education, and civic tech. Over 14 participants built working prototypes in a single evening, with judges awarding prizes for creativity, impact, and technical execution.</p>
-          <a href="hacknights24.html" class="recap-link">See the full recap <i class="fas fa-arrow-right"></i></a>
+          <span class="recap-eyebrow">April 21, 2026</span>
+          <h3>CharlestonHacks Happy Hour</h3>
+          <p>The community gathered at Revelry Brewery for an after-work social designed to connect Charleston's tech scene. Coders, designers, entrepreneurs, and the simply curious came out to unwind, network, and build lasting connections.</p>
+          <a href="https://www.meetup.com/charlestonhacks/events/314200042/" target="_blank" rel="noopener noreferrer" class="recap-link">View on Meetup <i class="fas fa-arrow-right"></i></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The Cloudflare Worker only returns future events from Meetup API, so the most recent past event (Happy Hour at Revelry Brewery, event 314200042) was not in the feed. Updated the fallback card to show this event with correct date, description, photo, and Meetup link. The JS still attempts to find past events from the worker in case the feed is updated to include them.