### PR TITLE
Fix homepage formatting and visual polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       width: 100%; height: 100%;
       z-index: -1;
       pointer-events: none;
+      opacity: 0.4;
     }
 
     /* Event countdown banner */
@@ -73,6 +74,19 @@
       font-family: 'Orbitron', Arial, sans-serif;
     }
 
+    /* Override styles.css background image overlay and pseudo-elements */
+    body::before,
+    body::after {
+      display: none !important;
+    }
+
+    /* Override styles.css .section-title leak */
+    .section-title {
+      text-align: left;
+      color: #fff;
+      margin-bottom: 8px;
+    }
+
     /* ── Nav ── */
     .top-nav {
       display: flex;
@@ -101,6 +115,8 @@
       text-align: center;
       padding: 72px 20px 48px;
       background: radial-gradient(ellipse at 50% 0%, rgba(0,224,255,0.08) 0%, transparent 65%);
+      position: relative;
+      z-index: 1;
     }
     .hero-eyebrow {
       display: inline-block;
@@ -124,6 +140,8 @@
       -webkit-text-fill-color: transparent;
       background-clip: text;
       margin-bottom: 20px;
+      text-shadow: none;
+      filter: drop-shadow(0 2px 12px rgba(0,0,0,0.5));
     }
     .hero p {
       max-width: 560px;
@@ -412,6 +430,7 @@
     .divider {
       border: none;
       border-top: 1px solid rgba(255,255,255,0.07);
+      margin: 0;
     }
 
     /* ── Photo gallery filmstrip ── */
@@ -463,8 +482,8 @@
       }
     }
     .gallery-item {
-      flex: 0 0 280px;
-      height: 200px;
+      flex: 0 0 340px;
+      height: 230px;
       border-radius: 12px;
       overflow: hidden;
       position: relative;
@@ -824,7 +843,7 @@
       .newsletter-box p { font-size: 0.9rem; }
 
       /* Gallery */
-      .gallery-item { flex: 0 0 240px; height: 170px; }
+      .gallery-item { flex: 0 0 260px; height: 180px; }
       .gallery-header { flex-direction: column; align-items: flex-start; gap: 4px; }
 
       /* Values */
@@ -888,7 +907,7 @@
   </div>
 
   <!-- Community Gallery -->
-  <div class="section" style="padding-bottom:0;">
+  <div class="section" style="padding-bottom:12px;">
     <div class="gallery-header">
       <p class="section-title" data-aos="fade-up">Community in Action</p>
     </div>


### PR DESCRIPTION
- Kill styles.css body::before/::after background image overlay that was bleeding through and adding visual noise behind hero
- Override styles.css .section-title color/alignment leak
- Reduce neural canvas opacity from 1.0 to 0.4 so hero text reads clearly against the background
- Add drop-shadow filter on hero h1 for better contrast
- Set hero z-index:1 to layer above canvas properly
- Increase gallery card size from 280px to 340px on desktop (was too small relative to viewport width)
- Add proper spacing between gallery title and strip
- Clean up divider margins