### PR TITLE
Move Upcoming Events above Get Involved pillars

### DIFF
--- a/index.html
+++ b/index.html
@@ -1000,6 +1000,21 @@
 
   <hr class="divider">
 
+  <!-- Upcoming Events -->
+  <div class="section" id="events-section">
+    <p class="section-title" data-aos="fade-up">Upcoming Events</p>
+    <p class="section-sub" data-aos="fade-up" data-aos-delay="60">What's happening in Charleston's tech scene.</p>
+
+    <div class="events-grid" id="homepage-events" data-aos="fade-up" data-aos-delay="120">
+      <!-- Skeleton placeholders while loading -->
+      <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
+      <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
+      <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
+    </div>
+  </div>
+
+  <hr class="divider">
+
   <!-- Primary Actions -->
   <div class="section">
     <p class="section-title" data-aos="fade-up">Get Involved</p>
@@ -1113,21 +1128,6 @@
         <h4>We Think Big Picture</h4>
         <p>We focus on long-term impact for Charleston's tech ecosystem, not just short-term wins.</p>
       </div>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- Upcoming Events -->
-  <div class="section" id="events-section">
-    <p class="section-title" data-aos="fade-up">Upcoming Events</p>
-    <p class="section-sub" data-aos="fade-up" data-aos-delay="60">What's happening in Charleston's tech scene.</p>
-
-    <div class="events-grid" id="homepage-events" data-aos="fade-up" data-aos-delay="120">
-      <!-- Skeleton placeholders while loading -->
-      <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
-      <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
-      <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
     </div>
   </div>
 


### PR DESCRIPTION
Events are the most actionable, time-sensitive content on the page. Moved from position 8 (after values) to position 4 (right after the photo gallery) so visitors see what's next within the first 1-2 scrolls.

New order: Hero → Stats → Gallery → Upcoming Events → Get Involved → Latest Event → Values → FAQ → Newsletter → Connect → Footer