### PR TITLE
System alignment: tighten funnel, reduce choices, direct action language

### DIFF
--- a/index.html
+++ b/index.html
@@ -1000,11 +1000,11 @@
     <h1>Charleston's Community for Builders, Hackers &amp; Makers</h1>
     <p class="hero-sub">We host events, connect people, and build things together. Whether you're shipping your first project or your fiftieth, there's a seat for you here.</p>
     <div class="hero-cta">
-      <a href="subscribe.html" class="btn-primary">
-        <i class="fas fa-users"></i> Join the Community
+      <a href="#events-section" class="btn-primary">
+        <i class="fas fa-calendar-alt"></i> Join the Next Event
       </a>
-      <a href="#events-section" class="btn-outline">
-        <i class="fas fa-calendar-alt"></i> Explore Events
+      <a href="https://deckerd451.github.io/innovation-engine/" target="_blank" rel="noopener noreferrer" class="btn-outline">
+        <i class="fas fa-project-diagram"></i> See Who's Here
       </a>
     </div>
     <div class="hero-scroll" aria-hidden="true">
@@ -1046,29 +1046,7 @@
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       4. WHAT IS CHARLESTONHACKS
-       ════════════════════════════════════════════════════════ -->
-  <div class="section" id="about-section">
-    <div class="about-grid" data-aos="fade-up">
-      <div class="about-text">
-        <p class="section-label">What is CharlestonHacks</p>
-        <h2>A home base for Charleston's tech community</h2>
-        <p>CharlestonHacks is an independent, community-led group that brings together coders, designers, entrepreneurs, and the simply curious. We run hack nights, show-and-tell demos, happy hours, and experimental builds — all free, all open to everyone.</p>
-        <p>We believe the best things get built when people connect across disciplines. No gatekeeping, no dues, no prerequisites. Just show up and make something.</p>
-      </div>
-      <div class="about-image">
-        <picture>
-          <source srcset="images/gallery/goodpartyshot.webp" type="image/webp">
-          <img src="images/goodpartyshot.jpg" alt="CharlestonHacks community gathering at a local event" loading="lazy">
-        </picture>
-      </div>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       5. UPCOMING EVENTS (PRIMARY CONVERSION)
+       4. UPCOMING EVENTS (PRIMARY CONVERSION)
        ════════════════════════════════════════════════════════ -->
   <div class="section" id="events-section">
     <p class="section-label" data-aos="fade-up">What's Next</p>
@@ -1091,7 +1069,7 @@
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       5b. FIND YOUR NEXT CONNECTION (Bridge — Phase 1)
+       5. FIND YOUR NEXT CONNECTION (Bridge)
        ════════════════════════════════════════════════════════ -->
   <div class="section" id="bridge-section">
     <p class="section-label" data-aos="fade-up">The Coordination Layer</p>
@@ -1127,71 +1105,31 @@
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       6. NEWSLETTER CTA (LOW-FRICTION CONVERSION)
+       6. WHAT IS CHARLESTONHACKS (moved down, after action)
        ════════════════════════════════════════════════════════ -->
-  <div class="section">
-    <div class="newsletter-box" data-aos="fade-up">
-      <h2>Stay in the Loop</h2>
-      <p>Get updates on events, projects, and opportunities from Charleston's tech community. No spam, just signal.</p>
-      <a href="subscribe.html" class="btn-primary">
-        <i class="fas fa-envelope-open-text"></i> Subscribe to the Newsletter
-      </a>
+  <div class="section" id="about-section">
+    <div class="about-grid" data-aos="fade-up">
+      <div class="about-text">
+        <p class="section-label">What is CharlestonHacks</p>
+        <h2>A home base for Charleston's tech community</h2>
+        <p>CharlestonHacks is an independent, community-led group that brings together coders, designers, entrepreneurs, and the simply curious. We run hack nights, show-and-tell demos, happy hours, and experimental builds — all free, all open to everyone.</p>
+        <p>No gatekeeping, no dues, no prerequisites. Just show up and make something.</p>
+      </div>
+      <div class="about-image">
+        <picture>
+          <source srcset="images/gallery/goodpartyshot.webp" type="image/webp">
+          <img src="images/goodpartyshot.jpg" alt="CharlestonHacks community gathering at a local event" loading="lazy">
+        </picture>
+      </div>
     </div>
   </div>
 
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       7. GET INVOLVED — 4 ACTION CARDS
+       7. COMMUNITY GALLERY (compact)
        ════════════════════════════════════════════════════════ -->
-  <div class="section" id="involve-section">
-    <p class="section-label" data-aos="fade-up">Take Action</p>
-    <p class="section-title" data-aos="fade-up">Get Involved</p>
-    <p class="section-sub" data-aos="fade-up" data-aos-delay="60">Four ways to plug in, depending on where you are.</p>
-
-    <div class="involve-grid">
-      <a class="involve-card" href="subscribe.html" data-aos="fade-up" data-aos-delay="0">
-        <div class="involve-icon"><i class="fas fa-users"></i></div>
-        <h3>Join the Community</h3>
-        <p>Subscribe to the newsletter and get connected with 500+ builders, designers, and makers in Charleston.</p>
-        <span class="card-arrow">Get started <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-      <a class="involve-card" href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" data-aos="fade-up" data-aos-delay="60">
-        <div class="involve-icon" style="background:rgba(201,163,94,0.12);color:#c9a35e;"><i class="fas fa-calendar-check"></i></div>
-        <h3>Attend Events</h3>
-        <p>Hack nights, show-and-tell demos, happy hours, and experimental builds. All free, all open.</p>
-        <span class="card-arrow" style="color:#c9a35e;">Find events <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-      <a class="involve-card" href="https://deckerd451.github.io/innovation-engine/" target="_blank" rel="noopener noreferrer" data-aos="fade-up" data-aos-delay="120">
-        <div class="involve-icon" style="background:rgba(0,255,136,0.1);color:#00ff88;"><i class="fas fa-rocket"></i></div>
-        <h3>Innovation Engine</h3>
-        <p>Explore the community network, discover projects, and connect directly with other members.</p>
-        <span class="card-arrow" style="color:#00ff88;">Launch dashboard <i class="fas fa-arrow-right"></i></span>
-      </a>
-
-      <a class="involve-card" href="bbs.html" data-aos="fade-up" data-aos-delay="180">
-        <div class="involve-icon"><i class="fas fa-terminal"></i></div>
-        <h3>Community BBS</h3>
-        <p>Real-time community chat with a retro terminal vibe. Drop in, say hello, or play Zork.</p>
-        <span class="card-arrow">Open terminal <i class="fas fa-arrow-right"></i></span>
-      </a>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       8. COMMUNITY GALLERY
-       ════════════════════════════════════════════════════════ -->
-  <div class="section" style="padding-bottom:0;">
-    <div class="gallery-header">
-      <p class="section-label" data-aos="fade-up">Photos</p>
-      <p class="section-title" data-aos="fade-up">Community in Action</p>
-    </div>
-  </div>
-  <div class="gallery-outer" style="padding-bottom:20px;" data-aos="fade-up" data-aos-delay="120">
+  <div class="gallery-outer" style="padding:20px 0;" data-aos="fade-up">
     <div class="gallery-strip" role="list" aria-label="Community photo gallery">
       <div class="gallery-item" role="listitem">
         <picture><source srcset="images/gallery/hnwinners.webp" type="image/webp"><img src="images/hnwinners.jpg" alt="Hack Nights 2024 winners on stage" loading="lazy"></picture>
@@ -1280,27 +1218,14 @@
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       9. EXPLORE THE HUB
+       8. MEMBER HUB (simplified)
        ════════════════════════════════════════════════════════ -->
   <div class="section">
     <div class="hub-preview" data-aos="fade-up">
       <p class="section-label">Go Deeper</p>
-      <p class="section-title" style="text-align:center;">Explore the Hub</p>
-      <p class="section-sub" style="text-align:center;max-width:520px;margin:0 auto 32px;">The interactive member portal with 9 portals to events, experiments, the Innovation Engine, community tools, and more.</p>
-
-      <div class="hub-features">
-        <span class="hub-feature"><i class="fas fa-code"></i> Hack Nights</span>
-        <span class="hub-feature"><i class="fas fa-lightbulb"></i> Show &amp; Tell</span>
-        <span class="hub-feature"><i class="fas fa-rocket"></i> Innovation Engine</span>
-        <span class="hub-feature"><i class="fas fa-flask"></i> Experiments</span>
-        <span class="hub-feature"><i class="fas fa-terminal"></i> BBS Chat</span>
-        <span class="hub-feature"><i class="fas fa-newspaper"></i> News Feed</span>
-        <span class="hub-feature"><i class="fas fa-heart"></i> Donations</span>
-        <span class="hub-feature"><i class="fas fa-gamepad"></i> Card Game</span>
-        <span class="hub-feature"><i class="fab fa-bitcoin"></i> BTC Tracker</span>
-      </div>
-
-      <a href="/hub.html" class="btn-primary">
+      <p class="section-title" style="text-align:center;">Member Hub</p>
+      <p class="section-sub" style="text-align:center;max-width:480px;margin:0 auto 28px;">Interactive portal with experiments, community tools, the Innovation Engine, and more. For members who want to go beyond events.</p>
+      <a href="/hub.html" class="btn-outline">
         <i class="fas fa-th-large"></i> Enter the Hub
       </a>
     </div>
@@ -1309,21 +1234,19 @@
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       10. FAQ
+       9. FAQ (essential only)
        ════════════════════════════════════════════════════════ -->
   <div class="section" id="faq-section">
-    <p class="section-label" data-aos="fade-up">Questions</p>
     <p class="section-title" data-aos="fade-up">Common Questions</p>
-    <p class="section-sub" data-aos="fade-up" data-aos-delay="60">Everything you need to know before showing up.</p>
 
-    <div class="faq-list" data-aos="fade-up" data-aos-delay="120">
+    <div class="faq-list" data-aos="fade-up" data-aos-delay="60">
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          Who can join CharlestonHacks?
+          Who can join?
           <i class="fas fa-plus faq-icon"></i>
         </button>
         <div class="faq-answer" role="region">
-          <p>Everyone. Students, career-changers, senior engineers, designers, founders, and the simply curious. We're not a gatekept club — if you're interested in building things, you belong here.</p>
+          <p>Everyone. Students, career-changers, senior engineers, designers, founders, and the simply curious. If you're interested in building things, you belong here.</p>
         </div>
       </div>
       <div class="faq-item">
@@ -1332,36 +1255,33 @@
           <i class="fas fa-plus faq-icon"></i>
         </button>
         <div class="faq-answer" role="region">
-          <p>Not at all. Many of our members are designers, project managers, writers, or people exploring tech for the first time. Hack nights and Show &amp; Tell sessions welcome all skill levels.</p>
+          <p>No. Many members are designers, project managers, writers, or people exploring tech for the first time. All skill levels welcome.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          What happens at a typical event?
+          Is there a cost?
           <i class="fas fa-plus faq-icon"></i>
         </button>
         <div class="faq-answer" role="region">
-          <p>It depends on the format. Hack nights are focused build sessions around a theme. Show &amp; Tell is casual — people demo what they've been working on. Happy hours are just good conversation. All events are free.</p>
+          <p>No. All CharlestonHacks events are free. We're supported by sponsors and community donations.</p>
         </div>
       </div>
-      <div class="faq-item">
-        <button class="faq-question" aria-expanded="false">
-          Is there a cost to participate?
-          <i class="fas fa-plus faq-icon"></i>
-        </button>
-        <div class="faq-answer" role="region">
-          <p>No. All CharlestonHacks events are free. We're supported by sponsors and community donations to keep it that way.</p>
-        </div>
-      </div>
-      <div class="faq-item">
-        <button class="faq-question" aria-expanded="false">
-          How do I stay updated on events?
-          <i class="fas fa-plus faq-icon"></i>
-        </button>
-        <div class="faq-answer" role="region">
-          <p>Subscribe to our <a href="subscribe.html">newsletter</a> for updates, or follow us on <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer">Meetup</a> and <a href="https://www.linkedin.com/company/charlestonhacks" target="_blank" rel="noopener noreferrer">LinkedIn</a> for event announcements.</p>
-        </div>
-      </div>
+    </div>
+  </div>
+
+  <hr class="divider">
+
+  <!-- ════════════════════════════════════════════════════════
+       10. NEWSLETTER (demoted, low-friction catch)
+       ════════════════════════════════════════════════════════ -->
+  <div class="section">
+    <div class="newsletter-box" data-aos="fade-up">
+      <h2>Stay Connected</h2>
+      <p>Get event announcements and community updates. No spam, just signal.</p>
+      <a href="subscribe.html" class="btn-outline">
+        <i class="fas fa-envelope-open-text"></i> Subscribe
+      </a>
     </div>
   </div>
 


### PR DESCRIPTION
- Hero CTAs: 'Join the Next Event' + 'See Who's Here' (direct, outcome-driven)
- Events moved to position 4 (first action after stats, before explanation)
- Bridge section at position 5 (coordination layer immediately after events)
- About section demoted to position 6 (context after action)
- Removed Get Involved section (redundant with bridge cards)
- Newsletter demoted to position 10 (after FAQ, not competing with action CTAs)
- Gallery stripped of header (compact, visual proof only)
- Hub section simplified (removed 9 feature pills, single CTA)
- FAQ trimmed to 3 essential questions
- Section order: Hero → Stats → Events → Bridge → About → Gallery → Hub → FAQ → Newsletter → Connect → Footer