### PR TITLE
Strip to core: 6 sections, 3 CTAs, one dominant path

### DIFF
--- a/index.html
+++ b/index.html
@@ -954,18 +954,18 @@
     </button>
     <div class="nav-links">
       <a href="#events-section">Events</a>
-      <a href="#about-section">Community</a>
-      <a href="https://deckerd451.github.io/innovation-engine/" target="_blank" rel="noopener noreferrer">Innovation Engine</a>
+      <a href="https://deckerd451.github.io/innovation-engine/" target="_blank" rel="noopener noreferrer">Network</a>
+      <a href="/hub.html">Hub</a>
       <a href="/about.html">About</a>
       <a href="subscribe.html" class="nav-join">Join</a>
     </div>
   </nav>
 
   <!-- ════════════════════════════════════════════════════════
-       2. HERO — 100vh
+       2. HERO
        ════════════════════════════════════════════════════════ -->
   <section class="hero" id="hero">
-    <span class="hero-eyebrow">Charleston, SC</span>
+    <span class="hero-eyebrow">Charleston, SC · 500+ members · All events free</span>
     <h1>Charleston's Community for Builders, Hackers &amp; Makers</h1>
     <p class="hero-sub">Charleston has the talent. It needs more coordinated interaction. We connect the right people at the right time through events, tools, and repeated collisions.</p>
     <div class="hero-cta">
@@ -983,44 +983,18 @@
   </section>
 
   <!-- ════════════════════════════════════════════════════════
-       3. SOCIAL PROOF — STATS BAR
-       ════════════════════════════════════════════════════════ -->
-  <div class="stats-bar" role="list">
-    <div class="stat-item" role="listitem" data-aos="fade-up" data-aos-delay="0">
-      <span class="stat-num" data-count="500" data-suffix="+">500+</span>
-      <span class="stat-label">Community Members</span>
-    </div>
-    <div class="stat-item" role="listitem" data-aos="fade-up" data-aos-delay="80">
-      <span class="stat-num" data-count="10" data-suffix="+">10+</span>
-      <span class="stat-label">Events Hosted</span>
-    </div>
-    <div class="stat-item" role="listitem" data-aos="fade-up" data-aos-delay="160">
-      <span class="stat-num" data-count="5" data-suffix="+">5+</span>
-      <span class="stat-label">Years Active</span>
-    </div>
-    <div class="stat-item" role="listitem" data-aos="fade-up" data-aos-delay="240">
-      <span class="stat-num" data-count="inf" data-suffix="">∞</span>
-      <span class="stat-label">Ideas Built</span>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       4. UPCOMING EVENTS (PRIMARY CONVERSION)
+       3. UPCOMING EVENTS
        ════════════════════════════════════════════════════════ -->
   <div class="section" id="events-section">
-    <p class="section-label" data-aos="fade-up">What's Next</p>
     <p class="section-title" data-aos="fade-up">Upcoming Events</p>
-    <p class="section-sub" data-aos="fade-up" data-aos-delay="60">Free events for builders at every level. RSVP on Meetup and show up.</p>
 
-    <div class="events-grid" id="homepage-events" data-aos="fade-up" data-aos-delay="120">
+    <div class="events-grid" id="homepage-events" data-aos="fade-up" data-aos-delay="80">
       <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
       <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
       <div class="event-card skeleton" aria-hidden="true"><div style="height:100px;"></div></div>
     </div>
 
-    <div class="events-cta" data-aos="fade-up" data-aos-delay="180">
+    <div class="events-cta" data-aos="fade-up" data-aos-delay="140">
       <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" class="btn-outline" style="margin-top:8px;">
         <i class="fab fa-meetup"></i> View All on Meetup
       </a>
@@ -1030,7 +1004,7 @@
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       5. FIND YOUR NEXT CONNECTION (Bridge)
+       4. COORDINATION LAYER
        ════════════════════════════════════════════════════════ -->
   <div class="section" id="bridge-section">
     <p class="section-label" data-aos="fade-up">Start Here</p>
@@ -1061,7 +1035,6 @@
 
     <p class="bridge-thesis" data-aos="fade-up" data-aos-delay="200">Charleston doesn't need more random networking. It needs more precise, repeated, intentional connections.</p>
 
-    <!-- Intent selector (secondary, contextual) -->
     <div class="intent-bar" id="intent-bar" data-aos="fade-up" data-aos-delay="240">
       <span class="intent-label">I'm here to:</span>
       <button class="intent-btn" data-intent="build"><i class="fas fa-hammer" style="margin-right:5px;"></i>Build</button>
@@ -1073,172 +1046,17 @@
   <hr class="divider">
 
   <!-- ════════════════════════════════════════════════════════
-       5b. THE LOOP (why repeated attendance matters)
+       5. THE LOOP
        ════════════════════════════════════════════════════════ -->
   <div class="section" style="padding-top:56px;padding-bottom:56px;">
     <div data-aos="fade-up" style="max-width:600px;margin:0 auto;text-align:center;">
-      <p class="section-label">How It Works</p>
       <p class="section-title" style="text-align:center;">Show Up Once. Then Show Up Again.</p>
       <p style="color:var(--text-muted);font-family:var(--font-body);font-size:0.9rem;line-height:1.7;margin-top:16px;">The first event you attend, you'll meet a few people. The second time, you'll recognize faces. By the third, you'll have collaborators, co-founders, or friends you didn't expect. That's how thin markets thicken — not through one big moment, but through repeated, intentional collisions with the same people.</p>
-      <a href="#events-section" class="btn-primary" style="margin-top:28px;">
-        <i class="fas fa-calendar-alt"></i> Join the Next Event
-      </a>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       6. FAQ (essential only)
-       ════════════════════════════════════════════════════════ -->
-  <div class="section" id="faq-section">
-    <p class="section-title" data-aos="fade-up">Common Questions</p>
-
-    <div class="faq-list" data-aos="fade-up" data-aos-delay="60">
-      <div class="faq-item">
-        <button class="faq-question" aria-expanded="false">
-          Who can join?
-          <i class="fas fa-plus faq-icon"></i>
-        </button>
-        <div class="faq-answer" role="region">
-          <p>Everyone. Students, career-changers, senior engineers, designers, founders, and the simply curious. If you're interested in building things, you belong here.</p>
-        </div>
-      </div>
-      <div class="faq-item">
-        <button class="faq-question" aria-expanded="false">
-          Do I need to know how to code?
-          <i class="fas fa-plus faq-icon"></i>
-        </button>
-        <div class="faq-answer" role="region">
-          <p>No. Many members are designers, project managers, writers, or people exploring tech for the first time. All skill levels welcome.</p>
-        </div>
-      </div>
-      <div class="faq-item">
-        <button class="faq-question" aria-expanded="false">
-          Is there a cost?
-          <i class="fas fa-plus faq-icon"></i>
-        </button>
-        <div class="faq-answer" role="region">
-          <p>No. All CharlestonHacks events are free. We're supported by sponsors and community donations.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       7. WHAT IS CHARLESTONHACKS
-       ════════════════════════════════════════════════════════ -->
-  <div class="section" id="about-section">
-    <div class="about-grid" data-aos="fade-up">
-      <div class="about-text">
-        <p class="section-label">What is CharlestonHacks</p>
-        <h2>A home base for Charleston's tech community</h2>
-        <p>CharlestonHacks is an independent, community-led group that brings together coders, designers, entrepreneurs, and the simply curious. We run hack nights, show-and-tell demos, happy hours, and experimental builds — all free, all open to everyone.</p>
-        <p>No gatekeeping, no dues, no prerequisites. Just show up and make something.</p>
-      </div>
-      <div class="about-image">
-        <picture>
-          <source srcset="images/gallery/goodpartyshot.webp" type="image/webp">
-          <img src="images/goodpartyshot.jpg" alt="CharlestonHacks community gathering at a local event" loading="lazy">
-        </picture>
-      </div>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       8. COMMUNITY GALLERY (trimmed to 6)
-       ════════════════════════════════════════════════════════ -->
-  <div class="gallery-outer" style="padding:20px 0;" data-aos="fade-up">
-    <div class="gallery-strip" role="list" aria-label="Community photo gallery">
-      <div class="gallery-item" role="listitem">
-        <picture><source srcset="images/gallery/hnwinners.webp" type="image/webp"><img src="images/hnwinners.jpg" alt="Hack Nights 2024 winners on stage" loading="lazy"></picture>
-        <span class="gallery-caption">Hack Nights '24 — Winners</span>
-      </div>
-      <div class="gallery-item" role="listitem">
-        <picture><source srcset="images/gallery/goodworking.webp" type="image/webp"><img src="images/goodworking.jpg" alt="Teams collaborating at Summer Hack" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Teams Building</span>
-      </div>
-      <div class="gallery-item" role="listitem">
-        <picture><source srcset="images/gallery/st2group1.webp" type="image/webp"><img src="images/st2group1.jpg" alt="Show and Tell community gathering" loading="lazy"></picture>
-        <span class="gallery-caption">Show &amp; Tell #2</span>
-      </div>
-      <div class="gallery-item" role="listitem">
-        <picture><source srcset="images/gallery/goodaward.webp" type="image/webp"><img src="images/goodaward.jpg" alt="Award ceremony at CharlestonHacks" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Awards</span>
-      </div>
-      <div class="gallery-item" role="listitem">
-        <picture><source srcset="images/gallery/dougexplaining.webp" type="image/webp"><img src="images/dougexplaining.jpg" alt="Doug presenting to the group" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Presentations</span>
-      </div>
-      <div class="gallery-item" role="listitem">
-        <picture><source srcset="images/gallery/venkatandteam.webp" type="image/webp"><img src="images/venkatandteam.jpg" alt="Venkat and team at Summer Hack" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Teamwork</span>
-      </div>
-      <!-- Duplicate set for seamless loop -->
-      <div class="gallery-item" role="listitem" aria-hidden="true">
-        <picture><source srcset="images/gallery/hnwinners.webp" type="image/webp"><img src="images/hnwinners.jpg" alt="" loading="lazy"></picture>
-        <span class="gallery-caption">Hack Nights '24 — Winners</span>
-      </div>
-      <div class="gallery-item" role="listitem" aria-hidden="true">
-        <picture><source srcset="images/gallery/goodworking.webp" type="image/webp"><img src="images/goodworking.jpg" alt="" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Teams Building</span>
-      </div>
-      <div class="gallery-item" role="listitem" aria-hidden="true">
-        <picture><source srcset="images/gallery/st2group1.webp" type="image/webp"><img src="images/st2group1.jpg" alt="" loading="lazy"></picture>
-        <span class="gallery-caption">Show &amp; Tell #2</span>
-      </div>
-      <div class="gallery-item" role="listitem" aria-hidden="true">
-        <picture><source srcset="images/gallery/goodaward.webp" type="image/webp"><img src="images/goodaward.jpg" alt="" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Awards</span>
-      </div>
-      <div class="gallery-item" role="listitem" aria-hidden="true">
-        <picture><source srcset="images/gallery/dougexplaining.webp" type="image/webp"><img src="images/dougexplaining.jpg" alt="" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Presentations</span>
-      </div>
-      <div class="gallery-item" role="listitem" aria-hidden="true">
-        <picture><source srcset="images/gallery/venkatandteam.webp" type="image/webp"><img src="images/venkatandteam.jpg" alt="" loading="lazy"></picture>
-        <span class="gallery-caption">Summer Hack — Teamwork</span>
-      </div>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       9. MEMBER HUB
-       ════════════════════════════════════════════════════════ -->
-  <div class="section">
-    <div class="hub-preview" data-aos="fade-up">
-      <p class="section-label">Go Deeper</p>
-      <p class="section-title" style="text-align:center;">Member Hub</p>
-      <p class="section-sub" style="text-align:center;max-width:480px;margin:0 auto 28px;">Interactive portal with experiments, community tools, the Innovation Engine, and more. For members who want to go beyond events.</p>
-      <a href="/hub.html" class="btn-outline">
-        <i class="fas fa-th-large"></i> Enter the Hub
-      </a>
-    </div>
-  </div>
-
-  <hr class="divider">
-
-  <!-- ════════════════════════════════════════════════════════
-       10. NEWSLETTER (low-friction catch)
-       ════════════════════════════════════════════════════════ -->
-  <div class="section">
-    <div class="newsletter-box" data-aos="fade-up">
-      <h2>Stay Connected</h2>
-      <p>Get event announcements and community updates. No spam, just signal.</p>
-      <a href="subscribe.html" class="btn-outline">
-        <i class="fas fa-envelope-open-text"></i> Subscribe
-      </a>
     </div>
   </div>
 
   <!-- ════════════════════════════════════════════════════════
-       11. FOOTER
+       6. FOOTER
        ════════════════════════════════════════════════════════ -->
   <footer>
     <div style="display:flex;justify-content:center;gap:16px;margin-bottom:16px;flex-wrap:wrap;">
@@ -1247,12 +1065,12 @@
       <a href="https://www.instagram.com/charlestonhacks/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
       <a href="https://github.com/charlestonhacks" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fab fa-github"></i></a>
       <a href="mailto:hello@charlestonhacks.com" aria-label="Email"><i class="fas fa-envelope"></i></a>
-      <a href="https://github.com/sponsors/deckerd451" target="_blank" rel="noopener noreferrer" aria-label="Sponsor"><i class="fas fa-heart" style="color:#db61a2;"></i></a>
     </div>
     <p>© 2026 CharlestonHacks · Charleston, SC ·
       <a href="/">Home</a> ·
       <a href="/about.html">About</a> ·
-      <a href="/hub.html">Member Hub</a>
+      <a href="/hub.html">Hub</a> ·
+      <a href="subscribe.html">Newsletter</a>
     </p>
   </footer>
 


### PR DESCRIPTION
Removed: stats bar, FAQ, about section, gallery, hub section, newsletter section
Merged: stats into hero eyebrow, social links into footer, hub/newsletter into nav
Kept: Hero → Events → Coordination Layer → The Loop → Footer

12 sections → 6
6 CTAs → 3
1633 lines → 1451

One path: see it, join it, find your people, keep showing up.