### PR TITLE
Hero upgrade: time proximity + social signal

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,7 @@
       font-size: 0.82rem;
       color: var(--cyan);
       font-family: var(--font-body);
+      opacity: 0.85;
     }
     .events-list {
       display: grid;
@@ -524,7 +525,7 @@
        ════════════════════════════════════════════════════════ -->
   <section class="hero" id="events">
     <div class="hero-inner">
-      <p class="hero-eyebrow">CharlestonHacks · Meet people building in Charleston</p>
+      <p class="hero-eyebrow">CharlestonHacks</p>
       <div id="hero-event">
         <p class="events-label">Next Event</p>
         <h1 class="hero-title skeleton" style="height:3rem;width:80%;margin:10px auto 0;border-radius:8px;">&nbsp;</h1>
@@ -783,11 +784,30 @@
             var link = safeText(ev.link || '#');
             var desc = safeText((ev.description || '').substring(0, 120));
             var date = safeText(formatDate(ev.startDate));
+
+            // Time proximity
+            var msAway = new Date(ev.startDate).getTime() - Date.now();
+            var daysAway = Math.ceil(msAway / 86400000);
+            var proximity = '';
+            if (daysAway <= 0) proximity = 'Today';
+            else if (daysAway === 1) proximity = 'Tomorrow';
+            else if (daysAway <= 7) proximity = daysAway + ' days away';
+            else proximity = date;
+
+            // Social signal
+            var rsvpCount = ev.rsvpCount || ev.yes_rsvp_count || 0;
+            var signal = '';
+            if (rsvpCount > 0) {
+              signal = rsvpCount + ' people going · Last event had 40+';
+            } else {
+              signal = 'Last event had 40+ builders';
+            }
+
             heroEvent.innerHTML =
-              '<p class="events-label">Next Event</p>' +
+              '<p class="events-label">Next Event — ' + proximity + '</p>' +
               '<h1 class="hero-title">' + title + '</h1>' +
-              '<p class="hero-sub">' + date + (desc ? ' · ' + desc + (ev.description && ev.description.length > 120 ? '…' : '') : '') + '</p>' +
-              '<p class="events-signal" style="margin-top:14px;">Last event had 40+ builders</p>';
+              (desc ? '<p class="hero-sub">' + desc + (ev.description && ev.description.length > 120 ? '…' : '') + '</p>' : '') +
+              '<p class="events-signal" style="margin-top:16px;">' + signal + '</p>';
             if (heroCta) { heroCta.style.display = 'flex'; }
             if (heroRsvp) { heroRsvp.href = link; heroRsvp.textContent = 'RSVP Now'; }
           }


### PR DESCRIPTION
- Eyebrow now shows 'Next Event — 3 days away' (or Tomorrow/Today)
- Social signal: '23 people going · Last event had 40+' (reads rsvpCount from feed)
- Falls back to 'Last event had 40+ builders' if no RSVP data
- Description on its own line (not concatenated with date)
- Eyebrow simplified to just 'CharlestonHacks' (event label carries the context)