### PR TITLE
Refine homepage next-event countdown to show precise time remaining

### DIFF
--- a/index.html
+++ b/index.html
@@ -874,12 +874,21 @@
         const start = getStart(ev);
         const date = safeText(formatDate(start));
         const msAway = new Date(start).getTime() - Date.now();
-        const daysAway = Math.ceil(msAway / 86400000);
+        const totalMinutesAway = Math.max(0, Math.floor(msAway / 60000));
+        const daysAway = Math.floor(totalMinutesAway / 1440);
+        const hoursAway = Math.floor((totalMinutesAway % 1440) / 60);
+        const minutesAway = totalMinutesAway % 60;
+
         let proximity = date;
-        if (daysAway <= 0) proximity = 'Today';
-        else if (daysAway === 1) proximity = 'Tomorrow';
-        else if (daysAway <= 7) proximity = 'In ' + daysAway + ' days';
-        else if (daysAway <= 14) proximity = date + ' · ' + daysAway + ' days away';
+        if (msAway <= 0) {
+          proximity = 'Starting now';
+        } else if (daysAway >= 14) {
+          proximity = date + ' · in ' + daysAway + 'd ' + hoursAway + 'h';
+        } else if (daysAway > 0) {
+          proximity = 'In ' + daysAway + 'd ' + hoursAway + 'h ' + minutesAway + 'm';
+        } else {
+          proximity = 'In ' + hoursAway + 'h ' + minutesAway + 'm';
+        }
 
         const rsvpCount = ev.rsvpCount || ev.yes_rsvp_count || ev.attendee_count || 0;
         const signal = rsvpCount >= 5 ? rsvpCount + ' people going' : 'Builders, designers, and founders already going';


### PR DESCRIPTION
### Motivation
- The homepage event proximity used coarse day-based rounding which could produce misleading labels near day boundaries.
- A more precise time-until-start readout (days/hours/minutes) provides clearer context for users deciding whether to attend or RSVP.
- Events far in the future should still display the absolute date while also indicating remaining time.

### Description
- Replaced day-bucket logic with minute-based math in `index.html`, computing `totalMinutesAway`, `daysAway`, `hoursAway`, and `minutesAway` for finer granularity.
- Updated proximity messaging to show `Starting now` for already-started events, `In Xd Yh Zm` for multi-day windows, `In Xh Ym` for same-day events, and `DATE · in Xd Yh` for events 14+ days out.
- Kept the new proximity string wired into the existing hero header label (`Next Event — ...`) and did not alter other event rendering behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a21e83e88329b0b80f635d19ce33)