### PR TITLE
Update Pulse section subtitle to remove Supabase placeholder text

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,7 +663,7 @@
     <section class="section content-section" id="pulse-section" aria-label="Community pulse" style="padding-top:20px;">
       <p class="section-label">Pulse</p>
       <h2 class="section-title">The network at a glance</h2>
-      <p class="section-sub">A lightweight community snapshot. These can be replaced by live Supabase counts when you are ready.</p>
+      <p class="section-sub">A lightweight community snapshot reflecting the latest community highlights and engagement trends.</p>
       <div class="pulse-grid">
         <div class="pulse-card"><span class="pulse-icon">👥</span><div class="pulse-value" data-target="500">0</div><div class="pulse-label">Members</div></div>
         <div class="pulse-card"><span class="pulse-icon">🚀</span><div class="pulse-value" data-target="24">0</div><div class="pulse-label">Active Projects</div></div>


### PR DESCRIPTION
### Motivation
- Replace an internal placeholder referencing future Supabase integration with a concise user-facing description for the Pulse section.

### Description
- Updated `index.html` to replace the Pulse section subheading from "A lightweight community snapshot. These can be replaced by live Supabase counts when you are ready." to "A lightweight community snapshot reflecting the latest community highlights and engagement trends."

### Testing
- Verified the change with `rg` to locate the original text, `git diff -- index.html` to confirm only the intended line changed, and inspected the file excerpt with `nl -ba index.html | sed -n '660,670p'`, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a344109c83298765b8cd881db3d9)