### PR TITLE
Match homepage logo size with About page

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
       gap: 8px;
     }
 
-    .nav-logo img { height: 38px; width: auto; display: block; filter: brightness(1.12); }
+    .nav-logo img { width: 140px; height: auto; display: block; filter: brightness(1.12); }
 
     .nav-links { display: flex; align-items: center; gap: 6px; margin-left: auto; }
     .nav-links a {
@@ -547,7 +547,7 @@
 
     @media (max-width: 768px) {
       .top-nav { padding: 0 16px; height: 54px; }
-      .nav-logo img { height: 34px; }
+      .nav-logo img { width: 140px; }
       .nav-links { display: none; }
       .nav-links.open {
         display: flex;


### PR DESCRIPTION
### Motivation
- Ensure the top-left CharlestonHacks logo on the homepage matches the visual size used on the About page for consistent branding.

### Description
- Update `index.html` CSS to replace the height-based rule with `width: 140px; height: auto;` for `.nav-logo img` and apply `width: 140px;` in the mobile `@media (max-width: 768px)` rule.

### Testing
- Verified the change and commit with `git commit` and inspected the file via `rg` and `nl | sed` to confirm the CSS lines were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a3e78554832990a2b719ca51ffa4)