### PR TITLE
Fix hidden homepage bridge/depth content when AOS fails to run

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,8 +621,8 @@
     <hr class="divider">
 
     <section class="section" id="bridge-section" style="padding-top:40px;padding-bottom:36px;">
-      <p class="section-title" data-aos="fade-up" style="text-align:center;margin-bottom:24px;font-size:1rem;font-weight:700;color:var(--text-dim);">How this works:</p>
-      <div class="flow-steps" data-aos="fade-up" data-aos-delay="60">
+      <p class="section-title" style="text-align:center;margin-bottom:24px;font-size:1rem;font-weight:700;color:var(--text-dim);">How this works:</p>
+      <div class="flow-steps">
         <a href="https://deckerd451.github.io/innovation-engine/" target="_blank" rel="noopener noreferrer" class="flow-step">
           <span class="flow-num" style="color:var(--cyan);">1</span>
           <span class="flow-text"><strong>See who’s building and find people to meet</strong> — projects, people, skills, and where overlap exists.</span>
@@ -641,7 +641,7 @@
     <hr class="divider">
 
     <section class="section" style="padding-top:40px;padding-bottom:40px;">
-      <div class="depth-links" data-aos="fade-up">
+      <div class="depth-links">
         <a href="subscribe.html" class="depth-link">Join the community →</a>
         <a href="https://deckerd451.github.io/innovation-engine/" target="_blank" rel="noopener noreferrer" class="depth-link">See active projects →</a>
         <a href="bbs.html" class="depth-link">Open chat →</a>


### PR DESCRIPTION
### Motivation
- Prevent large blank-looking areas on the homepage by removing reliance on AOS attributes that leave content transparent if the AOS script fails to initialize.

### Description
- Removed `data-aos` and `data-aos-delay` attributes from the "How this works" heading, the `.flow-steps` container, and the `.depth-links` container in `index.html` so those blocks remain visible even when AOS does not run.

### Testing
- Ran `git diff -- index.html` to verify only `index.html` markup changed and ran `git commit` to record the change, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a501a414832986df1e4c55e1cd31)