### PR TITLE
Update events section subheading copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -712,7 +712,7 @@
     <section class="section content-section" id="events-section" aria-label="Upcoming events">
       <p class="section-label">Upcoming</p>
       <h2 class="section-title">More ways to show up</h2>
-      <p class="section-sub">The next event stays first. Additional events appear here so the page still has depth without competing with the hero.</p>
+      <p class="section-sub">Browse upcoming events and plan what's next.</p>
       <div class="events-list" id="homepage-events" aria-live="polite">
         <div class="event-card skeleton" aria-hidden="true" style="height:94px;"></div>
         <div class="event-card skeleton" aria-hidden="true" style="height:94px;"></div>


### PR DESCRIPTION
### Motivation
- Replace an overly verbose events subheading with concise, action-oriented copy to improve clarity and encourage users to explore upcoming events.

### Description
- Updated the paragraph under the Events section in `index.html` from "The next event stays first. Additional events appear here so the page still has depth without competing with the hero." to "Browse upcoming events and plan what's next.".

### Testing
- Verified the change with `rg -n "Browse upcoming events and plan what's next\." index.html` and inspected the surrounding lines with `nl -ba index.html | sed -n '706,722p'`, both indicating the new copy is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a8d785b883298ef92bdac02c0420)