### PR TITLE
Gate Claude workflows on secrets and prepare for Node.js 24

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -19,6 +20,8 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       contents: read
       pull-requests: read
@@ -27,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -54,4 +57,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,11 +13,16 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '') &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       contents: read
       pull-requests: read
@@ -26,7 +31,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -47,4 +52,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
### Motivation
- Prevent the `claude-code-action` jobs from failing when Anthropic credentials are not configured by ensuring jobs only run when either `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is present.
- Address runner/runtime changes by proactively opting JavaScript actions into Node.js 24 to avoid the Node.js 20 deprecation window.
- Keep CI up-to-date by using the newer checkout action version that aligns with runner expectations.

### Description
- Added an `if:` guard to the `claude-review` job so it only runs when `secrets.CLAUDE_CODE_OAUTH_TOKEN` or `secrets.ANTHROPIC_API_KEY` is set in `.github/workflows/claude-code-review.yml`.
- Updated the `claude` job condition in `.github/workflows/claude.yml` to require the same secret-presence check in addition to the existing `@claude` event filters.
- Added `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to both workflows to opt JavaScript actions into Node.js 24.
- Bumped `actions/checkout@v4` to `actions/checkout@v5` in both workflows.

### Testing
- Ran `git diff` to verify the workflow changes and the diff output matched the intended guard, env setting, and action version updates (success).
- Committed the changes with `git commit` which completed successfully and produced commit `c321e50` (success).
- Attempted to parse the workflows with a small Python/YAML check using `yaml.safe_load`, which failed due to `PyYAML` not being installed in this environment (`ModuleNotFoundError: No module named 'yaml'`).
- Printed the updated workflow files with `nl` to confirm the final file contents and created the pull request metadata via the automated `make_pr` step (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c4235f8c83298202280ed90b787a)