### PR TITLE
Remove redundant upcoming-events rendering on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -702,13 +702,10 @@
           
         </div>
         <p class="hero-secondary">
-          <a href="#events-more">See more upcoming events ↓</a>
+          <a href="#events-section">See upcoming events ↓</a>
         </p>
       </div>
     </section>
-
-    <div id="events-more" class="events-list" aria-live="polite" style="padding:0 20px 48px;"></div>
-
 
 
     <section class="section" id="photo-reel" aria-label="Community photo reel" style="padding-top:22px;padding-bottom:28px;">
@@ -1022,40 +1019,27 @@
       }
 
       function renderMoreEvents(upcoming) {
-        const moreList = document.getElementById('events-more');
         const homepageEvents = document.getElementById('homepage-events');
+        if (!homepageEvents) return;
 
-        if (moreList) {
-          moreList.innerHTML = upcoming.slice(1, 3).map(function (ev) {
-            const link = safeText(ev.link || ev.url || 'https://www.meetup.com/charlestonhacks/');
-            const date = safeText(formatDate(getStart(ev)));
-            return '<div class="event-card">' +
-              '<h3>' + cleanTitle(ev.title || ev.name) + ' — ' + date + '</h3>' +
-              '<a href="' + link + '" target="_blank" rel="noopener noreferrer" class="event-link">View Event →</a>' +
-              '</div>';
-          }).join('');
+        const eventsToShow = upcoming.slice(1, 4);
+        if (!eventsToShow.length) {
+          homepageEvents.innerHTML = '<p class="events-empty"><i class="fas fa-calendar-xmark" style="margin-right:0.4rem;"></i>No additional upcoming events right now. Check back soon.</p>';
+          return;
         }
 
-        if (homepageEvents) {
-          const eventsToShow = upcoming.slice(0, 3);
-          if (!eventsToShow.length) {
-            homepageEvents.innerHTML = '<p class="events-empty"><i class="fas fa-calendar-xmark" style="margin-right:0.4rem;"></i>No upcoming events right now. Check back soon.</p>';
-            return;
-          }
-
-          homepageEvents.innerHTML = eventsToShow.map(function (ev) {
-            const link = safeText(ev.link || ev.url || 'https://www.meetup.com/charlestonhacks/');
-            const location = safeText(ev.location || ev.venue || '');
-            const description = safeText(String(ev.description || ev.desc || '').replace(/<[^>]*>/g, '').slice(0, 130));
-            const date = safeText(formatDate(getStart(ev)));
-            return '<div class="event-card">' +
-              '<div class="event-date">' + date + '</div>' +
-              '<h3><a href="' + link + '" target="_blank" rel="noopener noreferrer">' + cleanTitle(ev.title || ev.name) + '</a></h3>' +
-              (location ? '<p class="event-location">📍 ' + location + '</p>' : '') +
-              (description ? '<p class="event-desc">' + description + (description.length >= 130 ? '…' : '') + '</p>' : '') +
-              '</div>';
-          }).join('');
-        }
+        homepageEvents.innerHTML = eventsToShow.map(function (ev) {
+          const link = safeText(ev.link || ev.url || 'https://www.meetup.com/charlestonhacks/');
+          const location = safeText(ev.location || ev.venue || '');
+          const description = safeText(String(ev.description || ev.desc || '').replace(/<[^>]*>/g, '').slice(0, 130));
+          const date = safeText(formatDate(getStart(ev)));
+          return '<div class="event-card">' +
+            '<div class="event-date">' + date + '</div>' +
+            '<h3><a href="' + link + '" target="_blank" rel="noopener noreferrer">' + cleanTitle(ev.title || ev.name) + '</a></h3>' +
+            (location ? '<p class="event-location">📍 ' + location + '</p>' : '') +
+            (description ? '<p class="event-desc">' + description + (description.length >= 130 ? '…' : '') + '</p>' : '') +
+            '</div>';
+        }).join('');
       }
 
       async function loadEvents() {


### PR DESCRIPTION
### Motivation
- The page was rendering upcoming events in two places which duplicated the same content and confused the layout. 
- The hero section should highlight only the next event while the events list should show the following events, avoiding repetition. 
- Simplify client rendering logic so a single function updates one DOM list for maintainability and fewer edge cases.

### Description
- Removed the standalone `#events-more` container and corresponding duplicate markup under the hero and updated the hero link to point to `#events-section` instead of `#events-more`.
- Consolidated `renderMoreEvents` to target only `#homepage-events` and return early if the container is not present.
- Adjusted event selection to show additional events after the hero-featured event using `upcoming.slice(1, 4)` and simplified the HTML generation path by removing the old `moreList` branch.
- Kept `renderHero` unchanged in behavior other than ensuring it is the single source of truth for the featured event display.

### Testing
- Verified string presence/absence with `rg -n "More ways to show up|See more upcoming events|View Event|upcoming" index.html assets/js assets/css` and confirmed the hero link text and headings are correct.
- Confirmed the duplicate container was removed and the new slicing exists with `rg -n "events-more|See more upcoming events|See upcoming events|slice\(0, 3\)|slice\(1, 4\)" index.html` which returned the expected occurrences.
- Performed static inspection of the updated file regions with `nl -ba index.html | sed -n '696,740p;1008,1065p'` to validate the consolidated `renderMoreEvents` implementation and hero changes.
- All automated static checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c6f65bd48329b5210750ca7db4f9)