### PR TITLE
Update Support the Mission CTA to donations page

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,7 +797,7 @@
           <h3>Stay in the Loop</h3>
           <p>Get updates on events, projects, and opportunities in Charleston.</p>
         </a>
-        <a href="https://github.com/sponsors/deckerd451" target="_blank" rel="noopener noreferrer" class="cta-card">
+        <a href="https://charlestonhacks.com/donations.html" class="cta-card">
           <span class="cta-icon">💛</span>
           <h3>Support the Mission</h3>
           <p>Help keep building tools that make invisible networks visible.</p>


### PR DESCRIPTION
### Motivation
- Replace the homepage "Support the Mission" CTA so it opens the CharlestonHacks donations page at `https://charlestonhacks.com/donations.html` instead of the previous GitHub Sponsors URL.

### Description
- Updated the anchor in `index.html` to `href="https://charlestonhacks.com/donations.html"` and removed the `target="_blank"` and `rel="noopener noreferrer"` attributes from that CTA, then committed the change.

### Testing
- No automated tests were run because this is a single-line static HTML update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c9d563b88329b32c5a85b5ee6dc7)