### PR TITLE
Fix workflow: move secrets check from job-level if to step-level env

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   claude-review:
-    if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -35,8 +34,12 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: ${{ env.CLAUDE_TOKEN != '' || env.ANTHROPIC_KEY != '' }}
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
GitHub Actions doesn't allow referencing secrets in job-level if conditions. Moved the conditional to the step level using env vars mapped from secrets.