### PR TITLE
feat: add Nearify live-network join flow to event rendering

### DIFF
--- a/assets/css/events.css
+++ b/assets/css/events.css
@@ -130,3 +130,153 @@ h1 {
     font-size: 1.1rem;
   }
 }
+
+/* ── CharlestonHacks Event Cards (eventsFeed.js render) ─────────────── */
+
+.ch-event-card {
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  background: rgba(22, 41, 69, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: border-color 0.3s ease;
+}
+
+.ch-event-card:hover {
+  border-color: rgba(0, 224, 255, 0.2);
+}
+
+.ch-event-date {
+  font-size: 0.75rem;
+  color: #00e0ff;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.ch-event-title {
+  margin: 0 0 8px 0;
+  font-size: 1.1rem;
+}
+
+.ch-event-title a {
+  color: #fff;
+  text-decoration: none;
+  border-bottom: 1px solid #444;
+  transition: border-color 0.3s;
+}
+
+.ch-event-title a:hover {
+  border-color: #00e0ff;
+}
+
+.ch-event-location {
+  font-size: 0.85rem;
+  color: #aaa;
+  margin: 4px 0;
+}
+
+.ch-event-desc {
+  font-size: 0.9rem;
+  color: #888;
+  margin-top: 5px;
+  line-height: 1.4;
+}
+
+/* ── CTA Section ────────────────────────────────────────────────────── */
+
+.ch-event-cta {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Nearify badge label */
+.ch-nearify-badge {
+  display: inline-block;
+  width: 100%;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a78bfa;
+  margin-bottom: -0.25rem;
+}
+
+/* Primary CTA — Nearify Join */
+.ch-btn-nearify {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, #7c3aed, #6d28d9);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  box-shadow: 0 2px 8px rgba(124, 58, 237, 0.3);
+}
+
+.ch-btn-nearify:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(124, 58, 237, 0.45);
+}
+
+.ch-btn-nearify:active {
+  transform: translateY(0);
+}
+
+/* Secondary link — View on Meetup (when Nearify is primary) */
+.ch-link-meetup {
+  font-size: 0.8rem;
+  color: #8fa3bf;
+  text-decoration: none;
+  border-bottom: 1px dashed #555;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.ch-link-meetup:hover {
+  color: #00e0ff;
+  border-color: #00e0ff;
+}
+
+/* Fallback CTA — Meetup only (no Nearify) */
+.ch-btn-meetup {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #fff;
+  background: rgba(0, 224, 255, 0.12);
+  border: 1px solid rgba(0, 224, 255, 0.3);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.ch-btn-meetup:hover {
+  background: rgba(0, 224, 255, 0.2);
+  border-color: rgba(0, 224, 255, 0.5);
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .ch-event-cta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .ch-btn-nearify,
+  .ch-btn-meetup {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}

--- a/assets/js/eventsFeed.js
+++ b/assets/js/eventsFeed.js
@@ -60,28 +60,49 @@ export async function loadEvents({
       const description = safeText(event?.description || "");
       const location = safeText(event?.location || "");
       const dateStr = safeText(formatDateShort(event?.startDate));
+      const nearifyJoinUrl = event?.nearifyJoinUrl ? safeText(event.nearifyJoinUrl) : null;
 
       const eventEl = document.createElement("div");
-      eventEl.style.marginBottom = "1.5rem";
-      eventEl.style.paddingBottom = "1rem";
-      eventEl.style.borderBottom = "1px solid #333";
+      eventEl.className = "ch-event-card";
+
+      // Build CTA section based on Nearify availability
+      let ctaHtml = "";
+      if (nearifyJoinUrl) {
+        ctaHtml = `
+          <div class="ch-event-cta">
+            <span class="ch-nearify-badge">Live Nearify Experience Available</span>
+            <a href="${nearifyJoinUrl}" target="_blank" rel="noopener noreferrer" class="ch-btn-nearify">
+              Join Live Network
+            </a>
+            <a href="${link}" target="_blank" rel="noopener noreferrer" class="ch-link-meetup">
+              View on Meetup
+            </a>
+          </div>
+        `;
+      } else {
+        ctaHtml = `
+          <div class="ch-event-cta">
+            <a href="${link}" target="_blank" rel="noopener noreferrer" class="ch-btn-meetup">
+              Join on Meetup
+            </a>
+          </div>
+        `;
+      }
 
       eventEl.innerHTML = `
-        <div style="font-size:0.75rem;color:#00e0ff;margin-bottom:4px;text-transform:uppercase;">${dateStr}</div>
-        <h3 style="margin:0 0 8px 0;font-size:1.1rem;">
-          <a href="${link}" target="_blank" rel="noopener noreferrer"
-             style="color:#fff;text-decoration:none;border-bottom:1px solid #444;transition:border-color 0.3s;"
-             onmouseover="this.style.borderColor='#00e0ff'"
-             onmouseout="this.style.borderColor='#444'">${title}</a>
+        <div class="ch-event-date">${dateStr}</div>
+        <h3 class="ch-event-title">
+          <a href="${nearifyJoinUrl || link}" target="_blank" rel="noopener noreferrer">${title}</a>
         </h3>
-        ${location ? `<p style="font-size:0.85rem;color:#aaa;margin:4px 0;">📍 ${location}</p>` : ""}
+        ${location ? `<p class="ch-event-location">📍 ${location}</p>` : ""}
         ${
           description
-            ? `<p style="font-size:0.9rem;color:#888;margin-top:5px;line-height:1.4;">${description.substring(0, 150)}${
+            ? `<p class="ch-event-desc">${description.substring(0, 150)}${
                 description.length > 150 ? "..." : ""
               }</p>`
             : ""
         }
+        ${ctaHtml}
       `;
 
       list.appendChild(eventEl);

--- a/events-worker.js
+++ b/events-worker.js
@@ -5,7 +5,11 @@
  *
  * Fetches the public Meetup iCal feed — no API key required.
  * Returns JSON matching the shape the frontend already expects:
- *   { events: [{ title, link, startDate, description, location }] }
+ *   { events: [{ title, link, startDate, description, location, nearifyJoinUrl? }] }
+ *
+ * If a Nearify join URL is available for an event, it will be included
+ * as `nearifyJoinUrl`. The frontend uses this to render a primary
+ * "Join Live Network" CTA alongside the standard Meetup link.
  */
 
 const ICAL_URL = 'https://www.meetup.com/charlestonhacks/events/ical/';

--- a/hub.html
+++ b/hub.html
@@ -54,6 +54,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
   <link rel="stylesheet" href="styles.css"/>
   <link rel="stylesheet" href="/assets/css/portal.css"/>
+  <link rel="stylesheet" href="/assets/css/events.css"/>
 
   <!-- ✅ Minimal, safe header logo positioning (won’t fight your existing CSS) -->
   <style>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css">
+  <link rel="stylesheet" href="/assets/css/events.css">
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-6NDKG07DY6"></script>
@@ -964,8 +965,8 @@
           if (heroCta) heroCta.style.display = 'flex';
           if (heroRsvp) {
             heroRsvp.href = buildNearifyLink('Event');
-            heroRsvp.textContent = 'Join on Nearify';
-            console.log('[CTA Override] Using Nearify link for event:', NEARIFY_EVENT_ID);
+            heroRsvp.textContent = 'Join Live Network';
+            console.log('[CTA] Using Nearify link (no events):', NEARIFY_EVENT_ID);
 
             let fallback = heroRsvp.parentNode.querySelector('.cta-secondary');
             if (!fallback) {
@@ -974,7 +975,7 @@
               heroRsvp.parentNode.appendChild(fallback);
             }
 
-            fallback.innerHTML = `Prefer Meetup? <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener">RSVP here</a>`;
+            fallback.innerHTML = `Prefer Meetup? <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener">View on Meetup</a>`;
           }
           return;
         }
@@ -1012,9 +1013,11 @@
           '<p class="events-signal" style="margin-top:16px;">' + safeText(signal) + '</p>';
         if (heroCta) heroCta.style.display = 'flex';
         if (heroRsvp) {
-          heroRsvp.href = buildNearifyLink(event.name || event.title);
-          heroRsvp.textContent = 'Join on Nearify';
-          console.log('[CTA Override] Using Nearify link for event:', NEARIFY_EVENT_ID);
+          // Prefer worker-provided nearifyJoinUrl, fall back to buildNearifyLink
+          const nearifyUrl = ev.nearifyJoinUrl ? safeText(ev.nearifyJoinUrl) : buildNearifyLink(event.name || event.title);
+          heroRsvp.href = nearifyUrl;
+          heroRsvp.textContent = 'Join Live Network';
+          console.log('[CTA] Using Nearify link for event:', ev.nearifyJoinUrl ? 'worker-provided' : NEARIFY_EVENT_ID);
 
           let fallback = heroRsvp.parentNode.querySelector('.cta-secondary');
           if (!fallback) {
@@ -1023,7 +1026,7 @@
             heroRsvp.parentNode.appendChild(fallback);
           }
 
-          fallback.innerHTML = `Prefer Meetup? <a href="${link}" target="_blank" rel="noopener">RSVP here</a>`;
+          fallback.innerHTML = `Prefer Meetup? <a href="${link}" target="_blank" rel="noopener">View on Meetup</a>`;
         }
       }
 
@@ -1039,16 +1042,34 @@
 
         homepageEvents.innerHTML = eventsToShow.map(function (ev) {
           const event = ev;
-        const meetupUrl = event.link;
-        const link = safeText(meetupUrl || ev.url || 'https://www.meetup.com/charlestonhacks/');
+          const meetupUrl = event.link;
+          const link = safeText(meetupUrl || ev.url || 'https://www.meetup.com/charlestonhacks/');
+          const nearifyJoinUrl = ev.nearifyJoinUrl ? safeText(ev.nearifyJoinUrl) : null;
           const location = safeText(ev.location || ev.venue || '');
           const description = safeText(String(ev.description || ev.desc || '').replace(/<[^>]*>/g, '').slice(0, 130));
           const date = safeText(formatDate(getStart(ev)));
+
+          let ctaHtml = '';
+          if (nearifyJoinUrl) {
+            ctaHtml =
+              '<div class="ch-event-cta">' +
+              '<span class="ch-nearify-badge">Live Nearify Experience Available</span>' +
+              '<a href="' + nearifyJoinUrl + '" target="_blank" rel="noopener noreferrer" class="ch-btn-nearify">Join Live Network</a>' +
+              '<a href="' + link + '" target="_blank" rel="noopener noreferrer" class="ch-link-meetup">View on Meetup</a>' +
+              '</div>';
+          } else {
+            ctaHtml =
+              '<div class="ch-event-cta">' +
+              '<a href="' + link + '" target="_blank" rel="noopener noreferrer" class="ch-btn-meetup">Join on Meetup</a>' +
+              '</div>';
+          }
+
           return '<div class="event-card">' +
             '<div class="event-date">' + date + '</div>' +
-            '<h3><a href="' + link + '" target="_blank" rel="noopener noreferrer">' + cleanTitle(ev.title || ev.name) + '</a></h3>' +
+            '<h3><a href="' + (nearifyJoinUrl || link) + '" target="_blank" rel="noopener noreferrer">' + cleanTitle(ev.title || ev.name) + '</a></h3>' +
             (location ? '<p class="event-location">📍 ' + location + '</p>' : '') +
             (description ? '<p class="event-desc">' + description + (description.length >= 130 ? '…' : '') + '</p>' : '') +
+            ctaHtml +
             '</div>';
         }).join('');
       }


### PR DESCRIPTION
- Support nearifyJoinUrl from Cloudflare Worker events
- Primary CTA: 'Join Live Network' when Nearify URL available
- Secondary subtle link: 'View on Meetup' as fallback
- Preserve existing Meetup-only behavior when no Nearify URL
- Add event card CSS with responsive mobile layout
- Update hero CTA to prefer worker-provided Nearify URLs