### PR TITLE
feat: add /admin/ hub with authenticated navigation entry

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Admin Hub — CharlestonHacks</title>
+  <link rel="icon" href="/favicon.ico"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: linear-gradient(135deg, #0a0e27 0%, #1a1f3a 100%);
+      color: #fff;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+
+    .admin-hub {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    .admin-header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+
+    .admin-header h1 {
+      font-size: 2rem;
+      background: linear-gradient(135deg, #00e0ff, #00a8ff);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 0.5rem;
+    }
+
+    .admin-header p {
+      color: rgba(255,255,255,0.6);
+      font-size: 0.95rem;
+    }
+
+    .admin-user-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 2rem;
+      padding: 0.75rem 1rem;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 8px;
+    }
+
+    .admin-user-bar .user-info {
+      font-size: 0.85rem;
+      color: rgba(255,255,255,0.7);
+    }
+
+    .admin-user-bar .user-info strong {
+      color: #00e0ff;
+    }
+
+    .btn-sm {
+      padding: 0.4rem 0.9rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .btn-logout {
+      background: rgba(255,255,255,0.08);
+      color: rgba(255,255,255,0.7);
+      border: 1px solid rgba(255,255,255,0.15);
+    }
+
+    .btn-logout:hover {
+      background: rgba(255,255,255,0.12);
+      color: #fff;
+    }
+
+    .btn-login {
+      background: linear-gradient(135deg, #00e0ff, #00a8ff);
+      color: #fff;
+    }
+
+    .btn-login:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(0,224,255,0.3);
+    }
+
+    /* Tool cards grid */
+    .tools-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+      gap: 1.25rem;
+    }
+
+    .tool-card {
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(0, 224, 255, 0.15);
+      border-radius: 12px;
+      padding: 1.5rem;
+      text-decoration: none;
+      color: inherit;
+      transition: all 0.25s ease;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .tool-card:hover {
+      border-color: rgba(0, 224, 255, 0.5);
+      transform: translateY(-3px);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0,224,255,0.1);
+    }
+
+    .tool-card .tool-icon {
+      font-size: 1.5rem;
+      color: #00e0ff;
+    }
+
+    .tool-card h2 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #fff;
+    }
+
+    .tool-card p {
+      font-size: 0.85rem;
+      color: rgba(255,255,255,0.55);
+      line-height: 1.5;
+    }
+
+    .tool-card .tool-status {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: rgba(0, 224, 255, 0.7);
+      margin-top: auto;
+    }
+
+    .tool-card.disabled {
+      opacity: 0.45;
+      pointer-events: none;
+      border-color: rgba(255,255,255,0.06);
+    }
+
+    /* Auth gate */
+    .auth-gate {
+      text-align: center;
+      padding: 4rem 2rem;
+    }
+
+    .auth-gate h2 {
+      font-size: 1.4rem;
+      margin-bottom: 1rem;
+      color: rgba(255,255,255,0.85);
+    }
+
+    .auth-gate p {
+      color: rgba(255,255,255,0.5);
+      margin-bottom: 1.5rem;
+    }
+
+    .back-link {
+      display: inline-block;
+      margin-top: 2rem;
+      font-size: 0.85rem;
+      color: rgba(255,255,255,0.5);
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+
+    .back-link:hover {
+      color: #00e0ff;
+    }
+
+    [hidden] { display: none !important; }
+
+    @media (max-width: 600px) {
+      body { padding: 1rem; }
+      .tools-grid { grid-template-columns: 1fr; }
+      .admin-user-bar { flex-direction: column; gap: 0.5rem; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+  <div class="admin-hub">
+    <div class="admin-header">
+      <h1><i class="fas fa-terminal" style="margin-right:0.5rem;"></i>Admin Hub</h1>
+      <p>Internal tools for CharlestonHacks operations</p>
+    </div>
+
+    <!-- Auth gate: shown when not signed in -->
+    <div id="auth-gate" class="auth-gate">
+      <h2>Sign in required</h2>
+      <p>You need to be signed in to access admin tools.</p>
+      <button class="btn-sm btn-login" id="loginBtn">
+        <i class="fab fa-github" style="margin-right:0.4rem;"></i>Sign in with GitHub
+      </button>
+    </div>
+
+    <!-- Admin content: shown when signed in -->
+    <div id="admin-content" hidden>
+      <div class="admin-user-bar">
+        <span class="user-info">Signed in as <strong id="userDisplay"></strong></span>
+        <button class="btn-sm btn-logout" id="logoutBtn">Sign out</button>
+      </div>
+
+      <div class="tools-grid">
+        <a href="/admin/external-events.html" class="tool-card">
+          <span class="tool-icon"><i class="fas fa-satellite-dish"></i></span>
+          <h2>External Event Activation</h2>
+          <p>Match imported community events to Nearify experiences. Activate join flows for partner Meetups.</p>
+          <span class="tool-status">Active</span>
+        </a>
+
+        <a href="/dashboard/funnel.html" class="tool-card">
+          <span class="tool-icon"><i class="fas fa-chart-funnel"></i></span>
+          <h2>Funnel Analytics</h2>
+          <p>Track join-flow conversion from event discovery through Nearify activation and community engagement.</p>
+          <span class="tool-status">Active</span>
+        </a>
+
+        <a href="/organization-admin.html" class="tool-card">
+          <span class="tool-icon"><i class="fas fa-building"></i></span>
+          <h2>Organization Manager</h2>
+          <p>Create and manage organization profiles, post opportunities, and configure partner listings.</p>
+          <span class="tool-status">Active</span>
+        </a>
+
+        <div class="tool-card disabled">
+          <span class="tool-icon"><i class="fas fa-users-cog"></i></span>
+          <h2>Member Management</h2>
+          <p>View community members, manage roles, and review engagement metrics.</p>
+          <span class="tool-status">Coming soon</span>
+        </div>
+      </div>
+    </div>
+
+    <a href="/" class="back-link">← Back to CharlestonHacks</a>
+  </div>
+
+  <script type="module">
+    import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+    const supabase = createClient(
+      'https://mqbsjlgnsirqsmfnreqd.supabase.co',
+      'sb_publishable_hKGoZiLtCe6BxgQjG23h2Q_hbGC-At3',
+      { auth: { autoRefreshToken: true, persistSession: true } }
+    );
+
+    const authGate = document.getElementById('auth-gate');
+    const adminContent = document.getElementById('admin-content');
+    const userDisplay = document.getElementById('userDisplay');
+    const loginBtn = document.getElementById('loginBtn');
+    const logoutBtn = document.getElementById('logoutBtn');
+
+    function showAdmin(user) {
+      authGate.hidden = true;
+      adminContent.hidden = false;
+      userDisplay.textContent = user.user_metadata?.user_name || user.email || 'Admin';
+    }
+
+    function showGate() {
+      authGate.hidden = false;
+      adminContent.hidden = true;
+    }
+
+    // Check session on load
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session?.user) {
+      // TODO: Add stricter admin role check here once a role system exists.
+      // For now, any signed-in user can view the admin hub.
+      showAdmin(session.user);
+    } else {
+      showGate();
+    }
+
+    // Auth state changes
+    supabase.auth.onAuthStateChange((_event, sess) => {
+      if (sess?.user) {
+        showAdmin(sess.user);
+      } else {
+        showGate();
+      }
+    });
+
+    // Login
+    loginBtn.addEventListener('click', async () => {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'github',
+        options: { redirectTo: window.location.href }
+      });
+      if (error) console.error('[Admin] Login error:', error.message);
+    });
+
+    // Logout
+    logoutBtn.addEventListener('click', async () => {
+      await supabase.auth.signOut();
+      showGate();
+    });
+  </script>
+</body>
+</html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -838,6 +838,29 @@
             </span>
           </button>
 
+          <!-- Admin Hub link (visible to signed-in users) -->
+          <!-- TODO: Gate behind admin role check once role system exists -->
+          <a href="/admin/" id="dropdown-admin-hub" style="
+            width:100%;
+            padding:0.75rem 1rem;
+            background:transparent;
+            border:none;
+            border-radius:8px;
+            color:#fff;
+            font-size:0.95rem;
+            font-weight:500;
+            cursor:pointer;
+            display:flex;
+            align-items:center;
+            gap:0.75rem;
+            transition:all 0.2s;
+            text-align:left;
+            text-decoration:none;
+          ">
+            <i class="fas fa-terminal" style="color:#ffa500; font-size:1.1rem; width:20px;"></i>
+            <span>Admin Hub</span>
+          </a>
+
           <!-- Divider -->
           <div style="height:1px; background:rgba(255,255,255,0.1); margin:0.25rem 0;"></div>
 

--- a/hub.html
+++ b/hub.html
@@ -185,6 +185,8 @@
     <a href="/about.html">About</a>
     <a href="/hub.html">Member Portal</a>
     <a href="https://www.meetup.com/charlestonhacks/" target="_blank" rel="noopener noreferrer">Next Event</a>
+    <!-- TODO: Gate behind admin role check once role system exists -->
+    <a href="/admin/" id="nav-admin-link" hidden>Admin</a>
   </nav>
 
   <!-- Upcoming event countdown bar -->
@@ -434,6 +436,11 @@
       const { data: { session } } = await supabase.auth.getSession();
       localStorage.setItem("ch:lastScreen", "index");
       window.__CH_SESSION__ = session || null;
+
+      // Show admin nav link for signed-in users
+      // TODO: Gate behind admin role check once role system exists
+      const adminLink = document.getElementById('nav-admin-link');
+      if (adminLink && session?.user) adminLink.hidden = false;
     } catch (e) {
       console.warn("Auth gate session check failed:", e);
     } finally {


### PR DESCRIPTION
- Create /admin/index.html with auth-gated tool directory
- Cards link to: External Event Activation, Funnel Analytics, Org Manager
- Uses same Supabase GitHub OAuth as existing pages
- Add hidden 'Admin' link to hub.html nav (shown when signed in)
- Add 'Admin Hub' link to dashboard.html user dropdown
- TODO comments for stricter role-based gating later
- Self-contained page, no new dependencies or schema changes