### PR TITLE
fix: use SECURITY DEFINER RPC to bypass RLS for pulse metrics

### DIFF
--- a/assets/js/pulse-metrics.js
+++ b/assets/js/pulse-metrics.js
@@ -3,41 +3,45 @@
  * Fetches live Supabase counts and populates the "Network at a Glance"
  * pulse section on the home page.
  *
- * Cards are matched by their label text so the order in the HTML doesn't matter.
- * Metric mapping:
- *   Members        → community table (visible rows)
- *   Active Projects → projects table where status = 'active'
- *   Connections    → connections table (row count)
- *   Events This Year → /assets/data/events.json filtered to current calendar year
+ * Counts come from a SECURITY DEFINER RPC function (get_pulse_metrics)
+ * that safely bypasses RLS for aggregate-only data.  If the RPC is
+ * unavailable the module falls back to the hardcoded data-target values
+ * already in the HTML.
+ *
+ * SQL to deploy the RPC:
+ *   supabase/sql/functions/get_pulse_metrics.sql
  */
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const SUPABASE_URL = 'https://mqbsjlgnsirqsmfnreqd.supabase.co';
+const SUPABASE_URL     = 'https://mqbsjlgnsirqsmfnreqd.supabase.co';
 const SUPABASE_ANON_KEY = 'sb_publishable_hKGoZiLtCe6BxgQjG23h2Q_hbGC-At3';
 
-/** Animate a single .pulse-value element from its current displayed number to `target`. */
+/** Animate a single .pulse-value element to a new target. */
 function animateTo(el, target) {
   if (!el || !Number.isFinite(target) || target < 0) return;
-  delete el.dataset.counted; // reset so the existing observer doesn't skip it
   el.dataset.counted = 'true';
-  const from = parseInt(el.textContent.replace(/,/g, ''), 10) || 0;
+  const from     = parseInt(el.textContent.replace(/,/g, ''), 10) || 0;
   const duration = 1500;
-  const start = performance.now();
+  const start    = performance.now();
   function tick(now) {
     const progress = Math.min((now - start) / duration, 1);
-    const eased = 1 - Math.pow(1 - progress, 3);
+    const eased    = 1 - Math.pow(1 - progress, 3);
     el.textContent = Math.round(from + eased * (target - from)).toLocaleString();
     if (progress < 1) requestAnimationFrame(tick);
   }
   requestAnimationFrame(tick);
 }
 
-/** Update a card's data-target and, if the section is already in view, animate immediately. */
-function updateCard(label, value, sectionInView) {
+/**
+ * Update a card's data-target and animate if already in view,
+ * or reset to 0 so the IntersectionObserver triggers the animation
+ * naturally when the user scrolls down.
+ */
+function updateCard(labelText, value, sectionInView) {
   const card = [...document.querySelectorAll('.pulse-card')].find(c => {
     const lbl = c.querySelector('.pulse-label');
-    return lbl && lbl.textContent.trim().toLowerCase() === label.toLowerCase();
+    return lbl && lbl.textContent.trim().toLowerCase() === labelText.toLowerCase();
   });
   if (!card) return;
 
@@ -49,7 +53,7 @@ function updateCard(label, value, sectionInView) {
   if (sectionInView) {
     animateTo(el, value);
   } else {
-    // Reset so the IntersectionObserver-triggered animateCounters() picks up the new target
+    // Reset so animateCounters() (IntersectionObserver) picks up the new target
     delete el.dataset.counted;
     el.textContent = '0';
   }
@@ -57,55 +61,63 @@ function updateCard(label, value, sectionInView) {
 
 async function loadPulseMetrics() {
   try {
-    // Reuse the existing singleton if hub.js / portal.js already initialised it
+    // Re-use the singleton created by hub.js / portal.js when available
     const supabase = window.supabase || createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
+    // ── Fetch DB counts via SECURITY DEFINER RPC ──────────────────────────
+    // get_pulse_metrics() bypasses RLS so anonymous visitors get real counts.
+    const { data: metrics, error: rpcError } = await supabase.rpc('get_pulse_metrics');
+
+    if (rpcError) {
+      // RPC not deployed yet — log and keep hardcoded fallback values
+      console.warn('[pulse] get_pulse_metrics RPC unavailable:', rpcError.message,
+        '\nDeploy supabase/sql/functions/get_pulse_metrics.sql to enable live counts.');
+      return;
+    }
+
+    // ── Events this year from local JSON ─────────────────────────────────
     const currentYear = new Date().getFullYear();
+    let eventsThisYear = 0;
+    try {
+      const resp = await fetch('/assets/data/events.json');
+      if (resp.ok) {
+        const json = await resp.json();
+        eventsThisYear = (json.events || []).filter(e => {
+          try { return new Date(e.startDate).getFullYear() === currentYear; }
+          catch { return false; }
+        }).length;
+      }
+    } catch {
+      // Non-fatal — events count stays 0; hardcoded fallback remains
+    }
 
-    const [membersRes, projectsRes, connectionsRes, eventsResp] = await Promise.all([
-      supabase
-        .from('community')
-        .select('id', { count: 'exact', head: true })
-        .or('is_hidden.is.null,is_hidden.eq.false'),
-
-      supabase
-        .from('projects')
-        .select('id', { count: 'exact', head: true })
-        .eq('status', 'active'),
-
-      supabase
-        .from('connections')
-        .select('id', { count: 'exact', head: true }),
-
-      fetch('/assets/data/events.json').then(r => r.ok ? r.json() : { events: [] }).catch(() => ({ events: [] })),
-    ]);
-
-    const eventsThisYear = (eventsResp.events || []).filter(e => {
-      try { return new Date(e.startDate).getFullYear() === currentYear; } catch { return false; }
-    }).length;
-
-    // Determine if the pulse section is already scrolled into view
+    // ── Determine whether the pulse section is already scrolled into view ──
     const pulseSection = document.getElementById('pulse-section');
     const inView = pulseSection
       ? pulseSection.getBoundingClientRect().top < window.innerHeight * 0.9
       : false;
 
-    if (membersRes.count !== null)     updateCard('Members',           membersRes.count,     inView);
-    if (projectsRes.count !== null)    updateCard('Active Projects',   projectsRes.count,    inView);
-    if (connectionsRes.count !== null) updateCard('Connections',       connectionsRes.count, inView);
-    if (eventsThisYear > 0)            updateCard('Events This Year',  eventsThisYear,       inView);
+    // ── Push live values to the cards ────────────────────────────────────
+    // Only update a card when we have a valid (non-null) value from the DB.
+    // Events fall back to the hardcoded value when the JSON has no entries
+    // for the current year (eventsThisYear === 0 simply means "none found").
+    if (metrics.members         != null) updateCard('Members',          metrics.members,         inView);
+    if (metrics.active_projects != null) updateCard('Active Projects',  metrics.active_projects, inView);
+    if (metrics.connections     != null) updateCard('Connections',      metrics.connections,     inView);
+    // Always update Events — show the real count (even if 0)
+    updateCard('Events This Year', eventsThisYear, inView);
 
     console.log('[pulse] Live metrics loaded:', {
-      members: membersRes.count,
-      activeProjects: projectsRes.count,
-      connections: connectionsRes.count,
+      members:        metrics.members,
+      activeProjects: metrics.active_projects,
+      connections:    metrics.connections,
       eventsThisYear,
     });
   } catch (err) {
-    // Non-fatal — hardcoded fallback values remain visible
+    // Non-fatal — hardcoded fallback data-target values remain in the HTML
     console.warn('[pulse] Could not load live metrics, using fallback values:', err);
   }
 }
 
-// Kick off as soon as the module is executed (non-blocking)
+// Kick off immediately (non-blocking — won't delay page render)
 loadPulseMetrics();

--- a/supabase/sql/functions/get_pulse_metrics.sql
+++ b/supabase/sql/functions/get_pulse_metrics.sql
@@ -1,0 +1,33 @@
+-- =============================================================
+-- get_pulse_metrics()
+-- Public aggregate counts for the homepage "Network at a Glance"
+-- pulse section.
+--
+-- Runs as SECURITY DEFINER so it bypasses RLS and can count rows
+-- that the anon role cannot SELECT directly.  Only aggregate
+-- numbers are returned — no individual row data is exposed.
+--
+-- Usage (JavaScript):
+--   const { data } = await supabase.rpc('get_pulse_metrics');
+--   // data → { members: 42, connections: 380, active_projects: 7 }
+-- =============================================================
+
+CREATE OR REPLACE FUNCTION get_pulse_metrics()
+RETURNS json
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT json_build_object(
+    'members',         (SELECT count(*)::int FROM community
+                        WHERE is_hidden IS NULL OR is_hidden = false),
+    'connections',     (SELECT count(*)::int FROM connections),
+    'active_projects', (SELECT count(*)::int FROM projects
+                        WHERE status = 'active')
+  );
+$$;
+
+-- Allow the anonymous (public) role to call this function
+GRANT EXECUTE ON FUNCTION get_pulse_metrics() TO anon;
+GRANT EXECUTE ON FUNCTION get_pulse_metrics() TO authenticated;


### PR DESCRIPTION
Direct table counts from the anon role were returning 0 for community and connections because RLS blocks unauthenticated reads.

Changes:
- Add supabase/sql/functions/get_pulse_metrics.sql: SECURITY DEFINER function that returns {members, connections, active_projects} as aggregate counts only — no row data exposed to anon callers. Grants EXECUTE to anon and authenticated roles.

- Update assets/js/pulse-metrics.js to call supabase.rpc('get_pulse_metrics') instead of direct table selects.  Falls back gracefully with a clear console warning if the RPC has not been deployed yet.

- Fix Events This Year: removed the '>0' guard that was suppressing the live count when no events existed for the current year; 0 is now shown truthfully instead of keeping the stale hardcoded fallback.

To activate: run get_pulse_metrics.sql in the Supabase SQL editor.

https://claude.ai/code/session_019w71L5xQHZ612BFuWYKTbh