### PR TITLE
Fix desktop layout: icons behind navbar and card overflowing viewport

### DIFF
--- a/hub.html
+++ b/hub.html
@@ -126,8 +126,9 @@
     /* Push card below the fixed nav bar */
     .main-wrapper { padding-top: 80px; }
 
-    /* Larger card on desktop */
-    .media-container { max-width: 620px; }
+    /* Larger card on desktop — constrain height so card fits in viewport */
+    .media-container { max-width: 620px; max-height: calc(100vh - 100px); }
+    .media-container #missionImage { max-height: calc(100vh - 100px); width: auto; max-width: 100%; }
 
     @media (max-width: 768px) {
       .main-wrapper { padding-top: 70px; justify-content: flex-start; }

--- a/styles.css
+++ b/styles.css
@@ -1748,21 +1748,25 @@ input[type="submit"]:focus-visible {
 
   .icons-container {
     position: fixed;
-    top: 30px;
-    right: 40px;
+    top: 68px;
+    right: 16px;
     z-index: 100;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 26px;
-    padding: 0;
+    gap: 10px;
+    padding: 10px 8px;
     box-shadow: none;
+    background: rgba(0, 0, 0, 0.45);
+    border-radius: 40px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(10px);
   }
 
   .icons-container a {
-    width: 64px;
-    height: 64px;
-    font-size: 2.2rem;
+    width: 46px;
+    height: 46px;
+    font-size: 1.4rem;
     border-radius: 50%;
     color: var(--text-color);
     transition: background 0.3s, box-shadow 0.3s, color 0.3s;


### PR DESCRIPTION
- Move fixed right-sidebar icons from top: 30px to top: 68px so they clear the 58px fixed navbar instead of being partially hidden under it
- Reduce icon size (64px → 46px) and gap (26px → 10px) so all 8 icons fit within typical viewport heights without overflowing
- Add a visible pill background with subtle border to the icon column so it reads as a grouped UI element at smaller size
- Constrain .media-container and #missionImage to max-height: calc(100vh - 100px) on desktop so the card image fits in the viewport without being cut off at the bottom

https://claude.ai/code/session_01FHKU27GzyReXPNAC6AfbYB