### PR TITLE
Scope card max-height to desktop only to preserve mobile layout

### DIFF
--- a/hub.html
+++ b/hub.html
@@ -127,8 +127,12 @@
     .main-wrapper { padding-top: 80px; }
 
     /* Larger card on desktop — constrain height so card fits in viewport */
-    .media-container { max-width: 620px; max-height: calc(100vh - 100px); }
-    .media-container #missionImage { max-height: calc(100vh - 100px); width: auto; max-width: 100%; }
+    .media-container { max-width: 620px; }
+
+    @media (min-width: 769px) {
+      .media-container { max-height: calc(100vh - 100px); }
+      .media-container #missionImage { max-height: calc(100vh - 100px); width: auto; max-width: 100%; }
+    }
 
     @media (max-width: 768px) {
       .main-wrapper { padding-top: 70px; justify-content: flex-start; }


### PR DESCRIPTION
The max-height constraint on .media-container was applied globally, which could shrink the card on short-height mobile viewports (landscape, small phones). Moved it inside @media (min-width: 769px) so mobile continues to use its existing flex-start + max-width: 500px rules.

https://claude.ai/code/session_01FHKU27GzyReXPNAC6AfbYB