### PR TITLE
Fix card overflow without breaking clickable-area alignment

### DIFF
--- a/hub.html
+++ b/hub.html
@@ -126,12 +126,12 @@
     /* Push card below the fixed nav bar */
     .main-wrapper { padding-top: 80px; }
 
-    /* Larger card on desktop — constrain height so card fits in viewport */
+    /* Larger card on desktop — card is 2:3 (w:h), so limit width via viewport height */
     .media-container { max-width: 620px; }
 
     @media (min-width: 769px) {
-      .media-container { max-height: calc(100vh - 100px); }
-      .media-container #missionImage { max-height: calc(100vh - 100px); width: auto; max-width: 100%; }
+      /* min() keeps card ≤ 620px wide AND ≤ (100vh-100px) tall (2/3 ratio) */
+      .media-container { max-width: min(620px, calc((100vh - 100px) * 2 / 3)); }
     }
 
     @media (max-width: 768px) {


### PR DESCRIPTION
Previous fix used width:auto on the image, causing .card-stage to stay at 620px while the image shrank — making percentage-positioned portal buttons misalign on desktop.

Card is exactly 2:3 (840×1260px), so constrain the container width with min(620px, (100vh-100px)*2/3) instead. The image stays width:100%, .card-stage matches the container, and all button percentages remain correct. Mobile is unaffected (rule is inside min-width:769px).

https://claude.ai/code/session_01FHKU27GzyReXPNAC6AfbYB