### PR TITLE
Make photo reel section link to Poster.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,6 +721,7 @@
     <section class="section" id="photo-reel" aria-label="Community photo reel" style="padding-top:22px;padding-bottom:28px;">
       <p class="section-label">Moments</p>
       <h2 class="section-title">Built by the community</h2>
+      <a href="Poster.html" aria-label="View event poster" style="display:block;text-decoration:none;cursor:pointer;">
       <div class="image-scroll" role="region" aria-label="Side scrolling gallery of CharlestonHacks community photos">
         <div class="image-track">
           <img src="images/gallery/hnwinners.webp" alt="CharlestonHacks winners posing together">
@@ -737,6 +738,7 @@
           <img src="images/gallery/venkatandteam.webp" alt="Team presenting their project">
         </div>
       </div>
+      </a>
     </section>
 
     <hr class="divider">


### PR DESCRIPTION
Wraps the image-scroll div in a block-level anchor so clicking anywhere on the scrolling gallery navigates to Poster.html. The CSS-driven marquee animation is unaffected.

https://claude.ai/code/session_01FHKU27GzyReXPNAC6AfbYB