### PR TITLE
Fix hub desktop layout, add Mailchimp pulse metric, photo reel link

### DIFF
--- a/assets/js/pulse-metrics.js
+++ b/assets/js/pulse-metrics.js
@@ -59,14 +59,33 @@ function updateCard(labelText, value, sectionInView) {
   }
 }
 
+const MAILCHIMP_WORKER_URL = 'https://mailchimp-subscriber-count.dmhamilton1.workers.dev';
+
+/** Fetch active Mailchimp subscriber count; returns 0 on any failure. */
+async function fetchMailchimpSubscribers() {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 6000);
+    const resp = await fetch(MAILCHIMP_WORKER_URL, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!resp.ok) return 0;
+    const json = await resp.json();
+    return typeof json.subscribers === 'number' ? json.subscribers : 0;
+  } catch {
+    return 0;
+  }
+}
+
 async function loadPulseMetrics() {
   try {
     // Re-use the singleton created by hub.js / portal.js when available
     const supabase = window.supabase || createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
-    // ── Fetch DB counts via SECURITY DEFINER RPC ──────────────────────────
-    // get_pulse_metrics() bypasses RLS so anonymous visitors get real counts.
-    const { data: metrics, error: rpcError } = await supabase.rpc('get_pulse_metrics');
+    // ── Fetch DB counts + Mailchimp count in parallel ─────────────────────
+    const [{ data: metrics, error: rpcError }, mailchimpCount] = await Promise.all([
+      supabase.rpc('get_pulse_metrics'),
+      fetchMailchimpSubscribers(),
+    ]);
 
     if (rpcError) {
       // RPC not deployed yet — log and keep hardcoded fallback values
@@ -115,14 +134,19 @@ async function loadPulseMetrics() {
     // Only update a card when we have a valid (non-null) value from the DB.
     // Events fall back to the hardcoded value when the JSON has no entries
     // for the current year (eventsThisYear === 0 simply means "none found").
-    if (metrics.members         != null) updateCard('Members',          metrics.members,         inView);
+    // Members = Supabase community table + Mailchimp active subscribers
+    if (metrics.members != null) {
+      updateCard('Members', metrics.members + mailchimpCount, inView);
+    }
     if (metrics.active_projects != null) updateCard('Active Projects',  metrics.active_projects, inView);
     if (metrics.connections     != null) updateCard('Connections',      metrics.connections,     inView);
     // Always update Events — show the real count (even if 0)
     updateCard('Events This Year', eventsThisYear, inView);
 
     console.log('[pulse] Live metrics loaded:', {
-      members:        metrics.members,
+      membersDB:      metrics.members,
+      mailchimp:      mailchimpCount,
+      membersTotal:   metrics.members + mailchimpCount,
       activeProjects: metrics.active_projects,
       connections:    metrics.connections,
       eventsThisYear,

--- a/workers/mailchimp-subscriber-count.js
+++ b/workers/mailchimp-subscriber-count.js
@@ -1,0 +1,62 @@
+/**
+ * mailchimp-subscriber-count.js
+ * Cloudflare Worker — returns the active subscriber count for the
+ * CharlestonHacks Mailchimp audience.
+ *
+ * Deploy to Cloudflare Workers and set one environment secret:
+ *   MAILCHIMP_API_KEY  — your full Mailchimp API key (e.g. abc123...-us12)
+ *
+ * The API key never appears in source code; it lives only in the
+ * Cloudflare Worker secrets vault.
+ *
+ * Response: { "subscribers": 1436 }
+ */
+
+const DATACENTER  = 'us12';
+const AUDIENCE_ID = '3b95e0177a';
+
+export default {
+  async fetch(request, env) {
+    // CORS — allow requests from the CharlestonHacks domain
+    const corsHeaders = {
+      'Access-Control-Allow-Origin': 'https://charlestonhacks.com',
+      'Access-Control-Allow-Methods': 'GET',
+      'Content-Type': 'application/json',
+    };
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: corsHeaders });
+    }
+
+    try {
+      const url = `https://${DATACENTER}.api.mailchimp.com/3.0/lists/${AUDIENCE_ID}?fields=stats.member_count`;
+
+      const resp = await fetch(url, {
+        headers: {
+          // Mailchimp basic auth: any string + API key
+          Authorization: `Basic ${btoa(`anystring:${env.MAILCHIMP_API_KEY}`)}`,
+        },
+      });
+
+      if (!resp.ok) {
+        return new Response(
+          JSON.stringify({ error: `Mailchimp returned ${resp.status}` }),
+          { status: 502, headers: corsHeaders }
+        );
+      }
+
+      const data = await resp.json();
+      const subscribers = data?.stats?.member_count ?? null;
+
+      return new Response(
+        JSON.stringify({ subscribers }),
+        { status: 200, headers: corsHeaders }
+      );
+    } catch (err) {
+      return new Response(
+        JSON.stringify({ error: err.message }),
+        { status: 500, headers: corsHeaders }
+      );
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- **Fix hub.html desktop layout**: Icons were partially hidden behind the fixed navbar (`top: 30px` → `top: 68px`), reduced icon size so all 8 fit in viewport, added pill background. Card was overflowing viewport — constrained width using `min(620px, (100vh-100px)*2/3)` based on the card's exact 2:3 aspect ratio, keeping clickable-area button alignment intact.
- **Add Mailchimp subscriber count to Members pulse metric**: New Cloudflare Worker (`workers/mailchimp-subscriber-count.js`) fetches active subscriber count server-side (API key stored as Worker secret). `pulse-metrics.js` fetches it in parallel with Supabase and adds the result to the member count. Degrades gracefully to Supabase-only if the Worker is unreachable.
- **Photo reel links to Poster.html**: Wrapped the scrolling gallery in a block anchor — CSS marquee animation unaffected.
- **Fix pulse metric timing bug**: Supabase + Mailchimp fetches now run in parallel so live data is ready before the scroll animation fires.

## Test plan

- [ ] Visit `hub.html` on desktop — card fits in viewport, icons visible below navbar, portal buttons aligned on card
- [ ] Visit `hub.html` on mobile — card fills screen, bottom icon bar present
- [ ] Visit home page — clicking the photo reel opens `Poster.html`
- [ ] Scroll to Pulse section — Members shows Supabase count + Mailchimp subscribers (requires Worker deployed with `MAILCHIMP_API_KEY` secret set)
- [ ] With Worker unreachable, Members falls back to Supabase-only count

https://claude.ai/code/session_01FHKU27GzyReXPNAC6AfbYB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHKU27GzyReXPNAC6AfbYB)_