### PR TITLE
Add in-browser Show Editor to Hacker Theater

### DIFF
--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -3,6 +3,7 @@
  *
  * Loads show.json, manages segment state, drives the UI,
  * handles keyboard shortcuts, and coordinates the timer.
+ * Exposes window.ShowController for editor.js.
  * Depends on clips.js being loaded first.
  */
 
@@ -11,15 +12,17 @@
   // 1. LOAD SHOW DATA
   // ============================================================
 
-  let show = null;
-  let segments = [];
-  let currentIndex = 0;
+  let show          = null;
+  let publishedShow = null; // immutable reference to the fetched show.json
+  let segments      = [];
+  let currentIndex  = 0;
 
   try {
     const resp = await fetch('./show.json');
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    show = await resp.json();
-    segments = show.segments || [];
+    show          = await resp.json();
+    publishedShow = JSON.parse(JSON.stringify(show)); // deep-frozen reference
+    segments      = show.segments || [];
     if (segments.length === 0) throw new Error('show.json contains no segments.');
   } catch (err) {
     showError(`Failed to load show.json: ${err.message}`);
@@ -33,49 +36,30 @@
   const $ = id => document.getElementById(id);
 
   const dom = {
-    // Header
-    eventName:        $('event-name'),
-    eventDate:        $('event-date'),
-    segmentLabel:     $('segment-label'),
-    progressDots:     $('progress-dots'),
-
-    // Segment info
-    segTitle:         $('seg-title'),
-    segPanelist:      $('seg-panelist'),
-    segTimestamps:    $('seg-timestamps'),
-    segDuration:      $('seg-duration'),
-
-    // Question card
-    questionCard:     $('question-card'),
-    questionText:     $('question-text'),
-
-    // Timer
-    timerDisplay:     $('timer-display'),
-    timerBar:         $('timer-bar'),
-
-    // Playback status
-    statusDot:        $('status-dot'),
-    statusText:       $('status-text'),
-
-    // Queue
-    queueList:        $('queue-list'),
-
-    // Notes
-    notesPanel:       $('notes-panel'),
-    notesText:        $('notes-text'),
-    notesBackup:      $('notes-backup'),
-    notesPanelist:    $('notes-panelist'),
-
-    // Overlays
-    blackOverlay:     $('black-overlay'),
-    intermOverlay:    $('interm-overlay'),
-    intermClock:      $('interm-clock'),
-
-    // Error
-    errorBanner:      $('error-banner'),
-
-    // Video placeholder
-    placeholder:      $('video-placeholder'),
+    eventName:     $('event-name'),
+    eventDate:     $('event-date'),
+    segmentLabel:  $('segment-label'),
+    progressDots:  $('progress-dots'),
+    segTitle:      $('seg-title'),
+    segPanelist:   $('seg-panelist'),
+    segTimestamps: $('seg-timestamps'),
+    segDuration:   $('seg-duration'),
+    questionCard:  $('question-card'),
+    questionText:  $('question-text'),
+    timerDisplay:  $('timer-display'),
+    timerBar:      $('timer-bar'),
+    statusDot:     $('status-dot'),
+    statusText:    $('status-text'),
+    queueList:     $('queue-list'),
+    notesPanel:    $('notes-panel'),
+    notesText:     $('notes-text'),
+    notesBackup:   $('notes-backup'),
+    notesPanelist: $('notes-panelist'),
+    blackOverlay:  $('black-overlay'),
+    intermOverlay: $('interm-overlay'),
+    intermClock:   $('interm-clock'),
+    errorBanner:   $('error-banner'),
+    placeholder:   $('video-placeholder'),
   };
 
   // ============================================================
@@ -83,15 +67,15 @@
   // ============================================================
 
   const state = {
-    questionVisible: false,
-    notesVisible:    true,
-    timerRunning:    false,
-    timerTotal:      0,
-    timerRemaining:  0,
-    timerHandle:     null,
-    completed:       new Set(),
-    blackActive:     false,
-    intermActive:    false,
+    questionVisible:   false,
+    notesVisible:      true,
+    timerRunning:      false,
+    timerTotal:        0,
+    timerRemaining:    0,
+    timerHandle:       null,
+    completed:         new Set(),
+    blackActive:       false,
+    intermActive:      false,
     intermClockHandle: null,
   };
 
@@ -99,11 +83,15 @@
   // 4. INIT HEADER
   // ============================================================
 
-  dom.eventName.textContent = show.eventName || 'Hacker Theater';
-  dom.eventDate.textContent = formatDate(show.eventDate);
+  function _renderHeader() {
+    dom.eventName.textContent = show.eventName || 'Hacker Theater';
+    dom.eventDate.textContent = formatDate(show.eventDate);
+  }
+
+  _renderHeader();
 
   // ============================================================
-  // 5. BUILD QUEUE
+  // 5. QUEUE
   // ============================================================
 
   function buildQueue() {
@@ -127,7 +115,6 @@
       item.addEventListener('keydown', e => {
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); jumpTo(i); }
       });
-
       dom.queueList.appendChild(item);
     });
 
@@ -138,15 +125,13 @@
     const items = dom.queueList.querySelectorAll('.queue-item');
     items.forEach((el, i) => {
       el.classList.remove('completed', 'current');
-      if (state.completed.has(i))     el.classList.add('completed');
-      else if (i === currentIndex)    el.classList.add('current');
+      if (state.completed.has(i))  el.classList.add('completed');
+      else if (i === currentIndex) el.classList.add('current');
     });
 
-    // Scroll current item into view
     const current = dom.queueList.querySelector('.queue-item.current');
     if (current) current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 
-    // Progress dots
     dom.progressDots.innerHTML = '';
     segments.forEach((_, i) => {
       const dot = document.createElement('div');
@@ -170,41 +155,34 @@
 
     const seg = segments[index];
 
-    // Segment info
-    dom.segTitle.textContent     = seg.title    || '—';
-    dom.segPanelist.textContent  = seg.panelist ? `↳ ${seg.panelist}` : '';
+    dom.segTitle.textContent      = seg.title    || '—';
+    dom.segPanelist.textContent   = seg.panelist ? `↳ ${seg.panelist}` : '';
     dom.segTimestamps.textContent = `${fmtTime(seg.start || 0)} → ${fmtTime(seg.end || 0)}`;
     const clipLen = (seg.end || 0) - (seg.start || 0);
     dom.segDuration.textContent = `Clip length: ${fmtTime(clipLen)}`;
 
-    // Question card — hide and reset
     state.questionVisible = false;
     dom.questionCard.classList.remove('revealed');
     dom.questionText.classList.remove('hidden-text');
     dom.questionText.textContent = seg.question || '(No question provided)';
-    dom.questionCard.classList.add('hidden-card');
     hideQuestionCard();
 
-    // Timer — reset to segment duration
     const mins = seg.discussionMinutes || 5;
     state.timerTotal     = mins * 60;
     state.timerRemaining = state.timerTotal;
     renderTimer(state.timerRemaining, state.timerTotal);
 
-    // Moderator notes
-    dom.notesText.textContent     = seg.moderatorNotes  || '(No notes)';
-    dom.notesPanelist.textContent = seg.panelist        || '—';
-    dom.notesBackup.innerHTML = '';
+    dom.notesText.textContent     = seg.moderatorNotes || '(No notes)';
+    dom.notesPanelist.textContent = seg.panelist       || '—';
+    dom.notesBackup.innerHTML     = '';
     (seg.backupQuestions || []).forEach(q => {
       const li = document.createElement('li');
       li.textContent = q;
       dom.notesBackup.appendChild(li);
     });
 
-    // Cue video (do not play yet)
     Clips.cue(seg.youtubeId, seg.start || 0, seg.end || 0);
 
-    // Set up end-of-clip handler
     Clips.setOnEnd(() => {
       setStatus('ended', 'Clip ended');
       state.completed.add(index);
@@ -217,9 +195,7 @@
     refreshQueue();
     setStatus('paused', 'Ready — press Play');
 
-    if (autoPlay) {
-      setTimeout(() => playClip(), 300);
-    }
+    if (autoPlay) setTimeout(() => playClip(), 300);
   }
 
   function jumpTo(index) {
@@ -228,14 +204,38 @@
   }
 
   // ============================================================
-  // 7. PLAYBACK CONTROLS
+  // 7. REPLACE SHOW (called by editor.js via ShowController)
+  // ============================================================
+
+  function replaceShow(newShow) {
+    if (!newShow || !Array.isArray(newShow.segments)) return;
+    if (Clips.isPlaying()) Clips.pause();
+
+    show     = JSON.parse(JSON.stringify(newShow));
+    segments = show.segments;
+
+    _renderHeader();
+    state.completed = new Set();
+
+    // If current segment index is now out of range, reset to first
+    if (currentIndex >= segments.length) currentIndex = 0;
+
+    buildQueue();
+    if (segments.length > 0) {
+      loadSegment(currentIndex);
+    } else {
+      setStatus('paused', 'No segments loaded');
+    }
+  }
+
+  // ============================================================
+  // 8. PLAYBACK CONTROLS
   // ============================================================
 
   function playClip() {
     const seg = segments[currentIndex];
     if (!seg) return;
     Clips.load(seg.youtubeId, seg.start || 0, seg.end || 0);
-    // Brief pause after load to let player initialize, then play
     setTimeout(() => {
       Clips.play();
       setStatus('playing', 'Playing');
@@ -263,7 +263,7 @@
   }
 
   // ============================================================
-  // 8. QUESTION CARD
+  // 9. QUESTION CARD
   // ============================================================
 
   function revealQuestionCard() {
@@ -271,14 +271,14 @@
     dom.questionCard.classList.remove('hidden-card');
     dom.questionCard.classList.add('revealed');
     dom.questionText.classList.remove('hidden-text');
-    document.getElementById('btn-show-q').textContent = 'Hide Question';
+    $('btn-show-q').textContent = 'Hide Question';
   }
 
   function hideQuestionCard() {
     state.questionVisible = false;
     dom.questionCard.classList.remove('revealed');
     dom.questionText.classList.add('hidden-text');
-    document.getElementById('btn-show-q').textContent = 'Show Question';
+    $('btn-show-q').textContent = 'Show Question';
   }
 
   function toggleQuestion() {
@@ -287,7 +287,7 @@
   }
 
   function randomBackupQuestion() {
-    const seg = segments[currentIndex];
+    const seg     = segments[currentIndex];
     const backups = seg.backupQuestions || [];
     if (backups.length === 0) { toast('No backup questions defined.', 'info'); return; }
     const q = backups[Math.floor(Math.random() * backups.length)];
@@ -297,13 +297,13 @@
   }
 
   // ============================================================
-  // 9. DISCUSSION TIMER
+  // 10. DISCUSSION TIMER
   // ============================================================
 
   function startTimer() {
     if (state.timerRunning) return;
     state.timerRunning = true;
-    state.timerHandle = setInterval(tickTimer, 1000);
+    state.timerHandle  = setInterval(tickTimer, 1000);
   }
 
   function pauseTimer() {
@@ -336,33 +336,23 @@
   function renderTimer(remaining, total) {
     const display = dom.timerDisplay;
     const bar     = dom.timerBar;
+    const mins    = Math.floor(remaining / 60);
+    const secs    = remaining % 60;
 
-    const mins = Math.floor(remaining / 60);
-    const secs = remaining % 60;
     display.textContent = `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
 
-    // Warning classes
     display.classList.remove('warn-60', 'warn-30', 'warn-0');
     bar.classList.remove('warn-60', 'warn-30', 'warn-0');
 
-    if (remaining === 0) {
-      display.classList.add('warn-0');
-      bar.classList.add('warn-0');
-    } else if (remaining <= 30) {
-      display.classList.add('warn-30');
-      bar.classList.add('warn-30');
-    } else if (remaining <= 60) {
-      display.classList.add('warn-60');
-      bar.classList.add('warn-60');
-    }
+    if (remaining === 0)       { display.classList.add('warn-0');  bar.classList.add('warn-0');  }
+    else if (remaining <= 30)  { display.classList.add('warn-30'); bar.classList.add('warn-30'); }
+    else if (remaining <= 60)  { display.classList.add('warn-60'); bar.classList.add('warn-60'); }
 
-    // Progress bar
-    const pct = total > 0 ? (remaining / total) * 100 : 0;
-    bar.style.width = `${pct}%`;
+    bar.style.width = `${total > 0 ? (remaining / total) * 100 : 0}%`;
   }
 
   // ============================================================
-  // 10. BLACK SCREEN / INTERMISSION
+  // 11. BLACK SCREEN / INTERMISSION
   // ============================================================
 
   function activateBlack() {
@@ -392,15 +382,16 @@
 
   function updateIntermClock() {
     const now = new Date();
-    dom.intermClock.textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    dom.intermClock.textContent = now.toLocaleTimeString([], {
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
   }
 
-  // Dismiss either overlay on any key
   document.addEventListener('keydown', e => {
     if (state.blackActive || state.intermActive) {
       deactivateBlack();
       deactivateIntermission();
-      return; // swallow event; don't trigger other shortcuts
+      return;
     }
     handleShortcut(e);
   });
@@ -409,25 +400,25 @@
   dom.intermOverlay.addEventListener('click', deactivateIntermission);
 
   // ============================================================
-  // 11. MODERATOR NOTES TOGGLE
+  // 12. MODERATOR NOTES TOGGLE
   // ============================================================
 
   function toggleNotes() {
     state.notesVisible = !state.notesVisible;
-    const panel = dom.notesPanel;
-    if (state.notesVisible) panel.classList.remove('collapsed');
-    else                    panel.classList.add('collapsed');
+    if (state.notesVisible) dom.notesPanel.classList.remove('collapsed');
+    else                    dom.notesPanel.classList.add('collapsed');
   }
 
-  document.getElementById('notes-toggle-btn').addEventListener('click', toggleNotes);
+  $('notes-toggle-btn').addEventListener('click', toggleNotes);
 
   // ============================================================
-  // 12. KEYBOARD SHORTCUTS
+  // 13. KEYBOARD SHORTCUTS
   // ============================================================
 
   function handleShortcut(e) {
-    // Ignore when typing in an input/textarea
     if (['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) return;
+    // Suppress all shortcuts while the Show Editor is open
+    if (window.Editor && window.Editor.isOpen()) return;
 
     switch (e.key) {
       case ' ':
@@ -435,53 +426,35 @@
         if (Clips.isPlaying()) pauseClip();
         else                   playClip();
         break;
-      case 'ArrowRight':
-        e.preventDefault();
-        nextSegment();
-        break;
-      case 'ArrowLeft':
-        e.preventDefault();
-        prevSegment();
-        break;
-      case 'q': case 'Q':
-        toggleQuestion();
-        break;
-      case 'r': case 'R':
-        replayClip();
-        break;
-      case 'n': case 'N':
-        toggleNotes();
-        break;
-      case 'f': case 'F':
-        requestFullscreen();
-        break;
-      case 'b': case 'B':
-        activateBlack();
-        break;
-      case 'i': case 'I':
-        activateIntermission();
-        break;
+      case 'ArrowRight': e.preventDefault(); nextSegment();        break;
+      case 'ArrowLeft':  e.preventDefault(); prevSegment();        break;
+      case 'q': case 'Q': toggleQuestion();                        break;
+      case 'r': case 'R': replayClip();                            break;
+      case 'n': case 'N': toggleNotes();                           break;
+      case 'f': case 'F': requestFullscreen();                     break;
+      case 'b': case 'B': activateBlack();                         break;
+      case 'i': case 'I': activateIntermission();                  break;
     }
   }
 
   // ============================================================
-  // 13. FULLSCREEN
+  // 14. FULLSCREEN
   // ============================================================
 
   function requestFullscreen() {
     const el = document.querySelector('.video-wrapper');
     if (!el) return;
-    if (el.requestFullscreen)       el.requestFullscreen();
-    else if (el.webkitRequestFullscreen) el.webkitRequestFullscreen();
-    else if (el.mozRequestFullScreen)    el.mozRequestFullScreen();
+    if      (el.requestFullscreen)          el.requestFullscreen();
+    else if (el.webkitRequestFullscreen)    el.webkitRequestFullscreen();
+    else if (el.mozRequestFullScreen)       el.mozRequestFullScreen();
   }
 
   // ============================================================
-  // 14. PLAYBACK STATUS
+  // 15. PLAYBACK STATUS
   // ============================================================
 
-  function setStatus(state, text) {
-    dom.statusDot.className = `status-dot ${state}`;
+  function setStatus(statusClass, text) {
+    dom.statusDot.className    = `status-dot ${statusClass}`;
     dom.statusText.textContent = text;
   }
 
@@ -489,57 +462,48 @@
     if (ytState === 'error') {
       setStatus('error', errMsg || 'Playback error');
       showError(errMsg || 'YouTube playback error. Check the video ID in show.json.');
-    } else if (ytState === YT.PlayerState.PLAYING) {
-      setStatus('playing', 'Playing');
-    } else if (ytState === YT.PlayerState.PAUSED) {
-      setStatus('paused', 'Paused');
-    } else if (ytState === YT.PlayerState.ENDED) {
-      setStatus('ended', 'Ended');
-    } else if (ytState === YT.PlayerState.BUFFERING) {
-      setStatus('playing', 'Buffering…');
-    }
+    } else if (ytState === YT.PlayerState.PLAYING)    { setStatus('playing', 'Playing');     }
+    else if   (ytState === YT.PlayerState.PAUSED)     { setStatus('paused',  'Paused');      }
+    else if   (ytState === YT.PlayerState.ENDED)      { setStatus('ended',   'Ended');       }
+    else if   (ytState === YT.PlayerState.BUFFERING)  { setStatus('playing', 'Buffering…'); }
   });
 
   // ============================================================
-  // 15. WIRE CONTROL BUTTONS
+  // 16. WIRE CONTROL BUTTONS
   // ============================================================
 
   function wireBtn(id, fn) {
-    const el = document.getElementById(id);
+    const el = $(id);
     if (el) el.addEventListener('click', fn);
   }
 
-  wireBtn('btn-play',       playClip);
-  wireBtn('btn-pause',      pauseClip);
-  wireBtn('btn-replay',     replayClip);
-  wireBtn('btn-prev',       prevSegment);
-  wireBtn('btn-next',       nextSegment);
-  wireBtn('btn-show-q',     toggleQuestion);
-  wireBtn('btn-backup-q',   randomBackupQuestion);
-  wireBtn('btn-toggle-n',   toggleNotes);
-  wireBtn('btn-fullscreen', requestFullscreen);
-  wireBtn('btn-black',      activateBlack);
-  wireBtn('btn-interm',     activateIntermission);
-  wireBtn('btn-timer-start',startTimer);
-  wireBtn('btn-timer-pause',pauseTimer);
-  wireBtn('btn-timer-reset',resetTimer);
+  wireBtn('btn-play',        playClip);
+  wireBtn('btn-pause',       pauseClip);
+  wireBtn('btn-replay',      replayClip);
+  wireBtn('btn-prev',        prevSegment);
+  wireBtn('btn-next',        nextSegment);
+  wireBtn('btn-show-q',      toggleQuestion);
+  wireBtn('btn-backup-q',    randomBackupQuestion);
+  wireBtn('btn-toggle-n',    toggleNotes);
+  wireBtn('btn-fullscreen',  requestFullscreen);
+  wireBtn('btn-black',       activateBlack);
+  wireBtn('btn-interm',      activateIntermission);
+  wireBtn('btn-timer-start', startTimer);
+  wireBtn('btn-timer-pause', pauseTimer);
+  wireBtn('btn-timer-reset', resetTimer);
 
   // ============================================================
-  // 16. TOAST NOTIFICATIONS
+  // 17. TOAST / ERROR
   // ============================================================
 
   function toast(message, type = 'info') {
-    const container = document.getElementById('toast-container');
-    const el = document.createElement('div');
-    el.className = `toast toast--${type}`;
-    el.textContent = message;
+    const container = $('toast-container');
+    const el        = document.createElement('div');
+    el.className    = `toast toast--${type}`;
+    el.textContent  = message;
     container.appendChild(el);
     setTimeout(() => el.remove(), 3500);
   }
-
-  // ============================================================
-  // 17. ERROR DISPLAY
-  // ============================================================
 
   function showError(msg) {
     dom.errorBanner.textContent = msg;
@@ -581,7 +545,23 @@
   buildQueue();
   loadSegment(0);
 
-  // Show a boot toast once the YouTube API is ready
+  // Expose API for editor.js
+  window.ShowController = {
+    getShow:         () => JSON.parse(JSON.stringify({ ...show, segments })),
+    getPublishedShow: () => JSON.parse(JSON.stringify(publishedShow)),
+    replaceShow,
+    jumpToSegment:   jumpTo,
+    previewSegment:  (seg) => {
+      if (!seg || !seg.youtubeId) return;
+      Clips.cue(seg.youtubeId, seg.start || 0, seg.end || 0);
+      setStatus('paused', `Preview: ${seg.title || '—'}`);
+    },
+  };
+
+  // Signal editor.js that ShowController is ready
+  document.dispatchEvent(new CustomEvent('showcontroller:ready'));
+
+  // Boot toast once the YouTube IFrame player is ready
   const apiCheckInterval = setInterval(() => {
     if (Clips.isApiReady()) {
       clearInterval(apiCheckInterval);

--- a/hackertheater/editor.js
+++ b/hackertheater/editor.js
@@ -1,0 +1,853 @@
+/**
+ * editor.js — Hacker Theater Show Editor
+ *
+ * Injects a full-featured in-browser editor for show.json data.
+ * Depends on window.ShowController, which controller.js sets up
+ * and signals via the 'showcontroller:ready' custom event.
+ *
+ * No backend. No eval. No external libraries. No network writes.
+ */
+
+const Editor = (() => {
+
+  const LS_KEY = 'charlestonhacks.hackertheater.showDraft.v1';
+
+  let editorShow   = null; // working copy; persists across open/close within a session
+  let editingIndex = -1;   // index of segment in form; -1 = new segment
+  let _isOpen      = false;
+
+  // ============================================================
+  // 1. DOM INJECTION
+  // ============================================================
+
+  function injectDOM() {
+    // Draft banner — inserted between header and .app
+    const banner = document.createElement('div');
+    banner.id        = 'draft-banner';
+    banner.className = 'draft-banner';
+    banner.setAttribute('role', 'alert');
+    banner.style.display = 'none';
+    banner.innerHTML = `
+      <div class="draft-banner__inner">
+        <span class="draft-banner__icon">⚡</span>
+        <span class="draft-banner__text">Local draft available from a previous session.</span>
+        <div class="draft-banner__btns">
+          <button id="draft-use"       class="draft-banner__btn draft-banner__btn--primary">Use Draft</button>
+          <button id="draft-published" class="draft-banner__btn">Use Published</button>
+          <button id="draft-clear"     class="draft-banner__btn draft-banner__btn--danger">Clear Draft</button>
+        </div>
+      </div>
+    `;
+    const app = document.querySelector('.app');
+    if (app) document.body.insertBefore(banner, app);
+    else     document.body.appendChild(banner);
+
+    // Editor modal — full-page overlay
+    const modal = document.createElement('div');
+    modal.id        = 'editor-modal';
+    modal.className = 'editor-modal';
+    modal.setAttribute('role',       'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', 'Show Editor');
+    modal.innerHTML = _modalHTML();
+    document.body.appendChild(modal);
+  }
+
+  function _modalHTML() {
+    return `
+    <div class="editor-modal__inner">
+
+      <!-- Header -->
+      <div class="editor-modal__header">
+        <div class="editor-modal__header-left">
+          <span class="editor-modal__title">Show Editor</span>
+          <span id="ed-unsaved-dot" class="ed-unsaved-dot" style="display:none" title="Unsaved changes">●</span>
+        </div>
+        <div class="editor-modal__meta">
+          <div class="ed-meta-field">
+            <label class="ed-meta-label" for="ed-event-name">Event Name</label>
+            <input id="ed-event-name" class="ed-meta-input" type="text" placeholder="Hacker Theater" />
+          </div>
+          <div class="ed-meta-field">
+            <label class="ed-meta-label" for="ed-event-date">Date</label>
+            <input id="ed-event-date" class="ed-meta-input" type="date" />
+          </div>
+        </div>
+        <button id="ed-close-top" class="editor-modal__close" aria-label="Close editor">✕</button>
+      </div>
+
+      <!-- Body: segment list + form -->
+      <div class="editor-modal__body">
+
+        <!-- Left panel: segment list -->
+        <div class="ed-list-panel">
+          <div class="ed-list-header">
+            <span class="ed-list-header__title">
+              Segments <span id="ed-seg-count" class="ed-seg-count"></span>
+            </span>
+            <button id="ed-add-seg" class="btn btn--primary ed-add-btn">+ Add</button>
+          </div>
+          <div id="ed-seg-list" class="ed-seg-list">
+            <div id="ed-list-empty" class="ed-list-empty" style="display:none">
+              No segments yet.<br>Click <strong>+ Add</strong> to create one.
+            </div>
+          </div>
+        </div>
+
+        <!-- Right panel: edit form -->
+        <div class="ed-form-panel">
+
+          <div id="ed-form-empty" class="ed-form-empty">
+            <div class="ed-form-empty__icon">✏</div>
+            <p>Select a segment to edit, or click <strong>+ Add</strong> to create a new one.</p>
+          </div>
+
+          <div id="ed-form-content" class="ed-form-content" style="display:none">
+
+            <div class="ed-form-heading">
+              <span id="ed-form-heading-text">New Segment</span>
+            </div>
+
+            <div class="ed-form-body">
+
+              <div class="ed-field">
+                <label class="ed-label" for="ed-f-title">Title <span class="ed-required">*</span></label>
+                <input id="ed-f-title" class="ed-input" type="text"
+                       placeholder="AI Agents Are Eating Software" />
+              </div>
+
+              <div class="ed-field">
+                <label class="ed-label" for="ed-f-yturl">
+                  YouTube URL or Video ID <span class="ed-required">*</span>
+                </label>
+                <input id="ed-f-yturl" class="ed-input" type="text"
+                       placeholder="https://youtube.com/watch?v=... or VIDEO_ID" />
+                <div id="ed-f-ytid-hint" class="ed-field-hint"></div>
+              </div>
+
+              <div class="ed-field-row">
+                <div class="ed-field">
+                  <label class="ed-label" for="ed-f-start">
+                    Start Time <span class="ed-required">*</span>
+                  </label>
+                  <input id="ed-f-start" class="ed-input" type="text" placeholder="1:30 or 90" />
+                  <div class="ed-field-hint">seconds, mm:ss, or hh:mm:ss</div>
+                </div>
+                <div class="ed-field">
+                  <label class="ed-label" for="ed-f-end">
+                    End Time <span class="ed-required">*</span>
+                  </label>
+                  <input id="ed-f-end" class="ed-input" type="text" placeholder="3:20 or 200" />
+                  <div class="ed-field-hint">seconds, mm:ss, or hh:mm:ss</div>
+                </div>
+                <div class="ed-field ed-field--narrow">
+                  <label class="ed-label" for="ed-f-mins">
+                    Disc. Min. <span class="ed-required">*</span>
+                  </label>
+                  <input id="ed-f-mins" class="ed-input" type="number"
+                         min="1" max="60" placeholder="5" />
+                </div>
+              </div>
+
+              <div class="ed-field">
+                <label class="ed-label" for="ed-f-panelist">Panelist</label>
+                <input id="ed-f-panelist" class="ed-input" type="text" placeholder="Jane Smith" />
+              </div>
+
+              <div class="ed-field">
+                <label class="ed-label" for="ed-f-question">
+                  Primary Question <span class="ed-required">*</span>
+                </label>
+                <textarea id="ed-f-question" class="ed-textarea" rows="2"
+                          placeholder="What must happen before this becomes mainstream?"></textarea>
+              </div>
+
+              <div class="ed-field">
+                <label class="ed-label" for="ed-f-backups">
+                  Backup Questions
+                  <span class="ed-label-hint">(one per line)</span>
+                </label>
+                <textarea id="ed-f-backups" class="ed-textarea" rows="3"
+                          placeholder="What is overhyped here?&#10;What is underestimated?"></textarea>
+              </div>
+
+              <div class="ed-field">
+                <label class="ed-label" for="ed-f-notes">Moderator Notes</label>
+                <textarea id="ed-f-notes" class="ed-textarea" rows="3"
+                          placeholder="Guide discussion toward…"></textarea>
+              </div>
+
+              <div id="ed-validation-errors" class="ed-validation-errors" style="display:none"></div>
+
+            </div><!-- /ed-form-body -->
+
+            <div class="ed-form-footer">
+              <button id="ed-save-seg"    class="btn btn--primary">Save Segment</button>
+              <button id="ed-preview-seg" class="btn btn--secondary">▶ Preview</button>
+              <button id="ed-cancel-seg"  class="btn btn--ghost">Cancel</button>
+              <button id="ed-delete-seg"  class="btn btn--danger ed-delete-btn">Delete</button>
+            </div>
+
+          </div><!-- /ed-form-content -->
+
+        </div><!-- /ed-form-panel -->
+
+      </div><!-- /editor-modal__body -->
+
+      <!-- Footer: show-level actions -->
+      <div class="editor-modal__footer">
+        <button id="ed-apply-close"     class="btn btn--primary">✓ Apply &amp; Close</button>
+        <button id="ed-save-draft"      class="btn btn--secondary">Save Draft</button>
+        <button id="ed-export"          class="btn btn--secondary">↓ Export show.json</button>
+        <label  id="ed-import-label"    class="btn btn--ghost ed-import-label"
+                tabindex="0" role="button" aria-label="Import show.json">
+          ↑ Import show.json
+          <input id="ed-import-file" type="file" accept=".json"
+                 style="display:none" aria-hidden="true" />
+        </label>
+        <button id="ed-reset-published" class="btn btn--warning">↺ Reset to Published</button>
+        <button id="ed-close-bottom"    class="btn btn--ghost ed-close-btn">Close without Applying</button>
+      </div>
+
+    </div>
+    `;
+  }
+
+  // ============================================================
+  // 2. WIRE BUTTONS
+  // ============================================================
+
+  function wireButtons() {
+    const $  = id => document.getElementById(id);
+    const on = (id, fn) => { const el = $(id); if (el) el.addEventListener('click', fn); };
+
+    // Modal open/close
+    on('btn-edit-show',   openEditor);
+    on('ed-close-top',    closeEditor);
+    on('ed-close-bottom', closeEditor);
+
+    // Click on backdrop closes modal
+    $('editor-modal').addEventListener('click', e => {
+      if (e.target === $('editor-modal')) closeEditor();
+    });
+
+    // Segment list
+    on('ed-add-seg', () => openForm(-1));
+
+    // Delegated clicks on segment list items
+    $('ed-seg-list').addEventListener('click', e => {
+      const btn = e.target.closest('[data-action]');
+      if (!btn) return;
+      const action = btn.dataset.action;
+      const i      = parseInt(btn.dataset.i, 10);
+      if (action === 'edit')    openForm(i);
+      if (action === 'up')      moveUp(i);
+      if (action === 'down')    moveDown(i);
+      if (action === 'preview') previewFromList(i);
+      if (action === 'delete')  deleteSegment(i);
+    });
+
+    // Segment form
+    on('ed-save-seg',    saveSegment);
+    on('ed-cancel-seg',  cancelForm);
+    on('ed-delete-seg',  () => deleteSegment(editingIndex));
+    on('ed-preview-seg', previewFromForm);
+
+    // Live YouTube URL parse hint
+    $('ed-f-yturl').addEventListener('input', _updateYtHint);
+
+    // Footer
+    on('ed-apply-close',     applyAndClose);
+    on('ed-save-draft',      saveDraft);
+    on('ed-export',          exportShow);
+    on('ed-reset-published', resetToPublished);
+
+    // Import file
+    $('ed-import-file').addEventListener('change', e => {
+      const file = e.target.files[0];
+      if (file) importShow(file);
+      e.target.value = '';
+    });
+    $('ed-import-label').addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); $('ed-import-file').click(); }
+    });
+
+    // Draft banner
+    on('draft-use',       useDraft);
+    on('draft-published', hideDraftBanner);
+    on('draft-clear',     () => { clearDraft(); hideDraftBanner(); _toast('Draft cleared.', 'info'); });
+  }
+
+  function _updateYtHint() {
+    const raw  = document.getElementById('ed-f-yturl').value;
+    const hint = document.getElementById('ed-f-ytid-hint');
+    if (!raw.trim()) { hint.textContent = ''; return; }
+    const id = parseYouTubeId(raw);
+    if (id) {
+      hint.textContent    = `ID: ${id}`;
+      hint.style.color    = 'var(--green)';
+    } else {
+      hint.textContent    = 'Could not parse a YouTube video ID from this input.';
+      hint.style.color    = 'var(--red)';
+    }
+  }
+
+  // ============================================================
+  // 3. OPEN / CLOSE
+  // ============================================================
+
+  function openEditor() {
+    if (!window.ShowController) { _toast('Control room still loading, please wait.', 'info'); return; }
+    // Clone from running show on first open within a session;
+    // preserve in-progress edits if editor was already opened.
+    if (editorShow === null) {
+      editorShow = _deepClone(window.ShowController.getShow());
+    }
+    editingIndex = -1;
+    _isOpen      = true;
+
+    _populateMetaFields();
+    _renderSegList();
+    _showFormEmpty();
+    document.getElementById('editor-modal').classList.add('active');
+    document.getElementById('ed-event-name').focus();
+  }
+
+  function closeEditor() {
+    _isOpen = false;
+    document.getElementById('editor-modal').classList.remove('active');
+  }
+
+  // ============================================================
+  // 4. META FIELDS
+  // ============================================================
+
+  function _populateMetaFields() {
+    document.getElementById('ed-event-name').value = editorShow.eventName || '';
+    document.getElementById('ed-event-date').value = editorShow.eventDate || '';
+  }
+
+  function _readMetaFields() {
+    editorShow.eventName = document.getElementById('ed-event-name').value.trim() || 'Hacker Theater';
+    editorShow.eventDate = document.getElementById('ed-event-date').value;
+  }
+
+  // ============================================================
+  // 5. SEGMENT LIST RENDER
+  // ============================================================
+
+  function _renderSegList() {
+    const list = document.getElementById('ed-seg-list');
+    const segs  = editorShow.segments || [];
+    const empty = document.getElementById('ed-list-empty');
+
+    // Preserve scroll position
+    const scrollTop = list.scrollTop;
+
+    // Remove existing items (keep the empty-state div)
+    Array.from(list.querySelectorAll('.ed-seg-item')).forEach(el => el.remove());
+
+    document.getElementById('ed-seg-count').textContent = `(${segs.length})`;
+    empty.style.display = segs.length === 0 ? '' : 'none';
+
+    segs.forEach((seg, i) => {
+      const clipSecs = (seg.end || 0) - (seg.start || 0);
+      const isActive = i === editingIndex;
+      const el       = document.createElement('div');
+      el.className   = 'ed-seg-item' + (isActive ? ' ed-seg-item--active' : '');
+
+      el.innerHTML = `
+        <div class="ed-seg-item__reorder">
+          <button class="ed-icon-btn" data-action="up"   data-i="${i}"
+                  title="Move up"   ${i === 0              ? 'disabled' : ''}>↑</button>
+          <button class="ed-icon-btn" data-action="down" data-i="${i}"
+                  title="Move down" ${i === segs.length-1  ? 'disabled' : ''}>↓</button>
+        </div>
+        <div class="ed-seg-item__body" data-action="edit" data-i="${i}" role="button" tabindex="0"
+             aria-label="Edit segment ${i+1}: ${_escHtml(seg.title || 'Untitled')}">
+          <div class="ed-seg-item__num">SEG ${i + 1}</div>
+          <div class="ed-seg-item__title">${_escHtml(seg.title || '(Untitled)')}</div>
+          <div class="ed-seg-item__meta">
+            ${seg.panelist ? _escHtml(seg.panelist) + ' · ' : ''}${_fmtSecs(clipSecs)} clip · ${seg.discussionMinutes || 5}min
+          </div>
+        </div>
+        <div class="ed-seg-item__actions">
+          <button class="ed-icon-btn ed-icon-btn--preview" data-action="preview" data-i="${i}"
+                  title="Preview in player">▶</button>
+          <button class="ed-icon-btn ed-icon-btn--delete"  data-action="delete"  data-i="${i}"
+                  title="Delete segment">✕</button>
+        </div>
+      `;
+
+      // Keyboard support for the body click target
+      el.querySelector('.ed-seg-item__body').addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openForm(i); }
+      });
+
+      list.appendChild(el);
+    });
+
+    list.scrollTop = scrollTop;
+  }
+
+  // ============================================================
+  // 6. FORM OPEN / POPULATE / READ
+  // ============================================================
+
+  function openForm(index) {
+    editingIndex = index;
+    const isNew  = index === -1;
+
+    document.getElementById('ed-form-empty').style.display   = 'none';
+    document.getElementById('ed-form-content').style.display = '';
+    document.getElementById('ed-form-heading-text').textContent =
+      isNew ? 'New Segment' : `Edit Segment ${index + 1}`;
+    document.getElementById('ed-delete-seg').style.display = isNew ? 'none' : '';
+
+    _clearValidationErrors();
+    isNew ? _clearForm() : _populateForm(editorShow.segments[index]);
+    _renderSegList();
+    document.getElementById('ed-f-title').focus();
+  }
+
+  function _showFormEmpty() {
+    editingIndex = -1;
+    document.getElementById('ed-form-empty').style.display   = '';
+    document.getElementById('ed-form-content').style.display = 'none';
+    _clearValidationErrors();
+  }
+
+  function _clearForm() {
+    document.getElementById('ed-f-title').value    = '';
+    document.getElementById('ed-f-yturl').value    = '';
+    document.getElementById('ed-f-ytid-hint').textContent = '';
+    document.getElementById('ed-f-start').value    = '';
+    document.getElementById('ed-f-end').value      = '';
+    document.getElementById('ed-f-panelist').value = '';
+    document.getElementById('ed-f-question').value = '';
+    document.getElementById('ed-f-backups').value  = '';
+    document.getElementById('ed-f-notes').value    = '';
+    document.getElementById('ed-f-mins').value     = '5';
+  }
+
+  function _populateForm(seg) {
+    document.getElementById('ed-f-title').value    = seg.title    || '';
+    document.getElementById('ed-f-yturl').value    = seg.youtubeId || '';
+    const hint = document.getElementById('ed-f-ytid-hint');
+    if (seg.youtubeId) {
+      hint.textContent = `ID: ${seg.youtubeId}`;
+      hint.style.color = 'var(--green)';
+    } else {
+      hint.textContent = '';
+    }
+    document.getElementById('ed-f-start').value    = _fmtSecs(seg.start != null ? seg.start : '');
+    document.getElementById('ed-f-end').value      = _fmtSecs(seg.end   != null ? seg.end   : '');
+    document.getElementById('ed-f-panelist').value = seg.panelist || '';
+    document.getElementById('ed-f-question').value = seg.question || '';
+    document.getElementById('ed-f-backups').value  = (seg.backupQuestions || []).join('\n');
+    document.getElementById('ed-f-notes').value    = seg.moderatorNotes  || '';
+    document.getElementById('ed-f-mins').value     =
+      seg.discussionMinutes != null ? seg.discussionMinutes : 5;
+  }
+
+  function _readForm() {
+    const ytRaw      = document.getElementById('ed-f-yturl').value.trim();
+    const youtubeId  = parseYouTubeId(ytRaw);
+    const start      = parseTime(document.getElementById('ed-f-start').value);
+    const end        = parseTime(document.getElementById('ed-f-end').value);
+    const minsRaw    = document.getElementById('ed-f-mins').value;
+    const discussionMinutes = minsRaw !== '' ? parseFloat(minsRaw) : null;
+
+    const backupQuestions = document.getElementById('ed-f-backups').value
+      .split('\n').map(s => s.trim()).filter(Boolean);
+
+    const seg = {
+      title:            document.getElementById('ed-f-title').value.trim(),
+      youtubeId:        youtubeId || '',
+      start,
+      end,
+      panelist:         document.getElementById('ed-f-panelist').value.trim(),
+      question:         document.getElementById('ed-f-question').value.trim(),
+      backupQuestions,
+      moderatorNotes:   document.getElementById('ed-f-notes').value.trim(),
+      discussionMinutes,
+    };
+
+    return { seg, errors: _validateSegment(seg) };
+  }
+
+  // ============================================================
+  // 7. SEGMENT SAVE / CANCEL / DELETE / REORDER
+  // ============================================================
+
+  function saveSegment() {
+    _readMetaFields();
+    const { seg, errors } = _readForm();
+
+    if (errors.length > 0) {
+      _showValidationErrors(errors);
+      return;
+    }
+    _clearValidationErrors();
+
+    const segs = editorShow.segments || (editorShow.segments = []);
+
+    if (editingIndex === -1) {
+      segs.push(seg);
+      editingIndex = segs.length - 1;
+    } else {
+      segs[editingIndex] = seg;
+    }
+
+    _renderSegList();
+    document.getElementById('ed-form-heading-text').textContent =
+      `Edit Segment ${editingIndex + 1}`;
+    document.getElementById('ed-delete-seg').style.display = '';
+    _toast('Segment saved to editor.', 'success');
+  }
+
+  function cancelForm() {
+    _showFormEmpty();
+    _renderSegList();
+  }
+
+  function deleteSegment(index) {
+    const segs  = editorShow.segments || [];
+    if (index < 0 || index >= segs.length) return;
+    const label = segs[index].title || 'this segment';
+    if (!confirm(`Delete "${label}"?\n\nThis cannot be undone within the editor.`)) return;
+    segs.splice(index, 1);
+    _showFormEmpty();
+    _renderSegList();
+    _toast('Segment deleted.', 'info');
+  }
+
+  function moveUp(index) {
+    const segs = editorShow.segments;
+    if (index <= 0 || index >= segs.length) return;
+    [segs[index - 1], segs[index]] = [segs[index], segs[index - 1]];
+    if      (editingIndex === index)     editingIndex--;
+    else if (editingIndex === index - 1) editingIndex++;
+    _renderSegList();
+  }
+
+  function moveDown(index) {
+    const segs = editorShow.segments;
+    if (index < 0 || index >= segs.length - 1) return;
+    [segs[index], segs[index + 1]] = [segs[index + 1], segs[index]];
+    if      (editingIndex === index)     editingIndex++;
+    else if (editingIndex === index + 1) editingIndex--;
+    _renderSegList();
+  }
+
+  // ============================================================
+  // 8. PREVIEW
+  // ============================================================
+
+  function previewFromList(index) {
+    const seg = (editorShow.segments || [])[index];
+    if (!seg) return;
+    if (!seg.youtubeId) { _toast('This segment has no YouTube ID yet.', 'error'); return; }
+    window.ShowController.previewSegment(seg);
+    _toast(`Cueing preview: ${seg.title || 'segment'}`, 'info');
+  }
+
+  function previewFromForm() {
+    const { seg } = _readForm();
+    if (!seg.youtubeId) {
+      _showValidationErrors(['A valid YouTube URL or ID is required to preview.']);
+      return;
+    }
+    _clearValidationErrors();
+    window.ShowController.previewSegment(seg);
+    _toast(`Cueing preview: ${seg.title || 'segment'}`, 'info');
+  }
+
+  // ============================================================
+  // 9. APPLY & CLOSE
+  // ============================================================
+
+  function applyAndClose() {
+    _readMetaFields();
+    const segs = editorShow.segments || [];
+
+    if (segs.length === 0) {
+      if (!confirm('The show has no segments. Apply this empty show?')) return;
+    }
+
+    window.ShowController.replaceShow(editorShow);
+    editorShow = null; // reset so next open re-clones from the now-updated running show
+    closeEditor();
+    _toast('Show updated and applied.', 'success');
+  }
+
+  // ============================================================
+  // 10. DRAFT — localStorage
+  // ============================================================
+
+  function saveDraft() {
+    _readMetaFields();
+    try {
+      localStorage.setItem(LS_KEY, JSON.stringify(editorShow));
+      _toast('Draft saved to browser storage.', 'success');
+    } catch (e) {
+      _toast('Could not save draft: storage may be full.', 'error');
+    }
+  }
+
+  function clearDraft() {
+    try { localStorage.removeItem(LS_KEY); } catch {}
+  }
+
+  function _loadDraft() {
+    try {
+      const raw = localStorage.getItem(LS_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch { return null; }
+  }
+
+  function useDraft() {
+    if (!window.ShowController) { _toast('Still loading, please try again.', 'info'); return; }
+    const draft = _loadDraft();
+    if (!draft) { _toast('No draft found in storage.', 'error'); hideDraftBanner(); return; }
+    if (!draft.segments || !Array.isArray(draft.segments)) {
+      _toast('Draft is invalid — no segments found.', 'error');
+      hideDraftBanner();
+      return;
+    }
+    window.ShowController.replaceShow(draft);
+    hideDraftBanner();
+    _toast(
+      `Draft loaded: "${draft.eventName || 'Hacker Theater'}" · ${draft.segments.length} segment(s).`,
+      'success'
+    );
+  }
+
+  function checkDraft() {
+    const draft = _loadDraft();
+    if (draft) showDraftBanner();
+  }
+
+  function showDraftBanner() {
+    const el = document.getElementById('draft-banner');
+    if (el) el.style.display = '';
+  }
+
+  function hideDraftBanner() {
+    const el = document.getElementById('draft-banner');
+    if (el) el.style.display = 'none';
+  }
+
+  // ============================================================
+  // 11. EXPORT — download show.json
+  // ============================================================
+
+  function exportShow() {
+    _readMetaFields();
+    const json = JSON.stringify(editorShow, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement('a');
+    a.href     = url;
+    a.download = 'show.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    _toast('Exported show.json.', 'success');
+  }
+
+  // ============================================================
+  // 12. IMPORT — read local show.json file
+  // ============================================================
+
+  function importShow(file) {
+    const reader = new FileReader();
+    reader.onload = e => {
+      let parsed;
+      try {
+        parsed = JSON.parse(e.target.result);
+      } catch {
+        _toast('Import failed: file is not valid JSON.', 'error');
+        return;
+      }
+      if (!parsed || typeof parsed !== 'object') {
+        _toast('Import failed: unexpected file format.', 'error');
+        return;
+      }
+      if (!Array.isArray(parsed.segments)) {
+        _toast('Import failed: missing "segments" array.', 'error');
+        return;
+      }
+      editorShow = parsed;
+      _populateMetaFields();
+      _showFormEmpty();
+      _renderSegList();
+      _toast(
+        `Imported "${parsed.eventName || 'show'}" · ${parsed.segments.length} segment(s).`,
+        'success'
+      );
+    };
+    reader.onerror = () => _toast('Import failed: could not read file.', 'error');
+    reader.readAsText(file);
+  }
+
+  // ============================================================
+  // 13. RESET TO PUBLISHED
+  // ============================================================
+
+  function resetToPublished() {
+    if (!confirm(
+      'Reset to the published show.json?\n\nAll unsaved editor changes will be discarded.'
+    )) return;
+    editorShow = _deepClone(window.ShowController.getPublishedShow());
+    _populateMetaFields();
+    _showFormEmpty();
+    _renderSegList();
+    _toast('Reset to published show.json.', 'info');
+  }
+
+  // ============================================================
+  // 14. VALIDATION
+  // ============================================================
+
+  function _validateSegment(seg) {
+    const errors = [];
+    if (!seg.title)
+      errors.push('Title is required.');
+    if (!seg.youtubeId)
+      errors.push('YouTube URL / ID is required and must be parseable.');
+    if (seg.start === null || seg.start === undefined)
+      errors.push('Start time is required.');
+    if (seg.end === null || seg.end === undefined)
+      errors.push('End time is required.');
+    if (seg.start != null && seg.end != null && seg.end <= seg.start)
+      errors.push('End time must be greater than start time.');
+    if (!seg.question)
+      errors.push('Primary question is required.');
+    if (seg.discussionMinutes == null || isNaN(seg.discussionMinutes) || seg.discussionMinutes <= 0)
+      errors.push('Discussion minutes must be a positive number.');
+    return errors;
+  }
+
+  function _showValidationErrors(errors) {
+    const el = document.getElementById('ed-validation-errors');
+    el.style.display = '';
+    el.innerHTML = errors.map(
+      e => `<div class="ed-error-item">⚠ ${_escHtml(e)}</div>`
+    ).join('');
+  }
+
+  function _clearValidationErrors() {
+    const el = document.getElementById('ed-validation-errors');
+    if (!el) return;
+    el.style.display = 'none';
+    el.innerHTML     = '';
+  }
+
+  // ============================================================
+  // 15. PARSERS
+  // ============================================================
+
+  /**
+   * Extract an 11-char YouTube video ID from a URL or plain ID.
+   * Supports: watch?v=, youtu.be/, /embed/, /shorts/, and &t= params.
+   */
+  function parseYouTubeId(input) {
+    if (!input) return null;
+    input = input.trim();
+
+    // Already a plain 11-char ID
+    if (/^[a-zA-Z0-9_-]{11}$/.test(input)) return input;
+
+    try {
+      const url = new URL(input);
+      if (url.hostname.includes('youtube.com')) {
+        // /watch?v=ID
+        const v = url.searchParams.get('v');
+        if (v && /^[a-zA-Z0-9_-]{11}$/.test(v)) return v;
+        // /embed/ID or /shorts/ID
+        const pathMatch = url.pathname.match(/\/(embed|shorts)\/([a-zA-Z0-9_-]{11})/);
+        if (pathMatch) return pathMatch[2];
+      }
+      if (url.hostname === 'youtu.be') {
+        const id = url.pathname.slice(1).split('?')[0].split('/')[0];
+        if (/^[a-zA-Z0-9_-]{11}$/.test(id)) return id;
+      }
+    } catch {}
+
+    // Regex fallback for malformed URLs
+    const m = input.match(/(?:[?&]v=|\/embed\/|\/shorts\/|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    return m ? m[1] : null;
+  }
+
+  /**
+   * Parse a time value to seconds.
+   * Accepts: integer seconds ("95"), mm:ss ("1:35"), hh:mm:ss ("1:02:15").
+   */
+  function parseTime(val) {
+    if (val === '' || val === null || val === undefined) return null;
+    val = String(val).trim();
+    if (/^\d+$/.test(val)) return parseInt(val, 10);
+    if (/^\d+\.\d+$/.test(val)) return Math.round(parseFloat(val));
+    const mmss = val.match(/^(\d{1,2}):(\d{2})$/);
+    if (mmss) return parseInt(mmss[1], 10) * 60 + parseInt(mmss[2], 10);
+    const hhmmss = val.match(/^(\d{1,2}):(\d{2}):(\d{2})$/);
+    if (hhmmss)
+      return parseInt(hhmmss[1], 10) * 3600
+           + parseInt(hhmmss[2], 10) * 60
+           + parseInt(hhmmss[3], 10);
+    return null;
+  }
+
+  // ============================================================
+  // 16. HELPERS
+  // ============================================================
+
+  function _fmtSecs(s) {
+    if (s === '' || s === null || s === undefined) return '';
+    s = Number(s);
+    if (isNaN(s)) return '';
+    return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+  }
+
+  function _deepClone(obj) { return JSON.parse(JSON.stringify(obj)); }
+
+  function _escHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function _toast(message, type = 'info') {
+    const container = document.getElementById('toast-container');
+    if (!container) return;
+    const el       = document.createElement('div');
+    el.className   = `toast toast--${type}`;
+    el.textContent = message;
+    container.appendChild(el);
+    setTimeout(() => el.remove(), 3500);
+  }
+
+  // ============================================================
+  // 17. INIT
+  // ============================================================
+
+  function init() {
+    injectDOM();
+    wireButtons();
+    checkDraft();
+  }
+
+  // Boot when controller.js signals it's ready
+  document.addEventListener('showcontroller:ready', init);
+
+  return {
+    open:   openEditor,
+    close:  closeEditor,
+    isOpen: () => _isOpen,
+  };
+
+})();

--- a/hackertheater/index.html
+++ b/hackertheater/index.html
@@ -13,15 +13,9 @@
 
   <!-- ============================================================
        BLACK SCREEN OVERLAY
-       Press any key or click to dismiss.
   ============================================================ -->
   <div id="black-overlay" class="overlay overlay--black" role="dialog" aria-label="Black screen mode" aria-modal="true">
-    <img
-      src="/charlestonhackslogo.svg"
-      alt="CharlestonHacks"
-      class="overlay__logo"
-      onerror="this.style.display='none'"
-    />
+    <img src="/charlestonhackslogo.svg" alt="CharlestonHacks" class="overlay__logo" onerror="this.style.display='none'" />
     <p class="overlay__hint">Press any key to return</p>
   </div>
 
@@ -29,12 +23,7 @@
        INTERMISSION OVERLAY
   ============================================================ -->
   <div id="interm-overlay" class="overlay overlay--intermission" role="dialog" aria-label="Intermission screen" aria-modal="true">
-    <img
-      src="/charlestonhackslogo.svg"
-      alt="CharlestonHacks"
-      class="overlay__logo"
-      onerror="this.style.display='none'"
-    />
+    <img src="/charlestonhackslogo.svg" alt="CharlestonHacks" class="overlay__logo" onerror="this.style.display='none'" />
     <div class="overlay__title">INTERMISSION</div>
     <div class="overlay__subtitle">Returning Shortly</div>
     <div id="interm-clock" class="overlay__clock"></div>
@@ -50,12 +39,7 @@
        SITE HEADER
   ============================================================ -->
   <header class="site-header" role="banner">
-    <img
-      src="/charlestonhackslogo.svg"
-      alt="CharlestonHacks"
-      class="header__logo"
-      onerror="this.style.display='none'"
-    />
+    <img src="/charlestonhackslogo.svg" alt="CharlestonHacks" class="header__logo" onerror="this.style.display='none'" />
 
     <div class="header__info">
       <div id="event-name" class="header__event-name">Hacker Theater</div>
@@ -69,6 +53,11 @@
   </header>
 
   <!-- ============================================================
+       DRAFT BANNER — injected here by editor.js
+       (editor.js inserts #draft-banner before .app at runtime)
+  ============================================================ -->
+
+  <!-- ============================================================
        MAIN APP — 3-column control room layout
   ============================================================ -->
   <main class="app" role="main">
@@ -76,12 +65,10 @@
     <!-- ==================== LEFT COLUMN ==================== -->
     <section class="col-left" aria-label="Video and content">
 
-      <!-- Error Banner -->
       <div id="error-banner" class="error-banner" role="alert"></div>
 
       <!-- Video Player -->
       <div class="video-wrapper" aria-label="YouTube video player">
-        <!-- YouTube IFrame API replaces this div -->
         <div id="yt-player"></div>
         <div id="video-placeholder" class="video-placeholder">
           <div class="video-placeholder__icon">▶</div>
@@ -92,7 +79,7 @@
       <!-- Segment Info -->
       <div class="segment-info" role="region" aria-label="Current segment">
         <div>
-          <div id="seg-title" class="segment-info__title">—</div>
+          <div id="seg-title"    class="segment-info__title">—</div>
           <div id="seg-panelist" class="segment-info__panelist"></div>
           <div id="seg-duration" class="segment-info__duration"></div>
         </div>
@@ -138,31 +125,18 @@
       <div class="control-panel" role="group" aria-label="Playback controls">
         <div class="panel__header"><span class="panel__title">Playback</span></div>
         <div class="panel__body">
-
           <button id="btn-play" class="btn btn--primary" aria-label="Play clip (Space)">
             ▶ Play Clip
           </button>
-
           <div class="btn-row">
-            <button id="btn-pause" class="btn btn--secondary" aria-label="Pause (Space)">
-              ⏸ Pause
-            </button>
-            <button id="btn-replay" class="btn btn--secondary" aria-label="Replay clip (R)">
-              ↺ Replay
-            </button>
+            <button id="btn-pause"  class="btn btn--secondary" aria-label="Pause (Space)">⏸ Pause</button>
+            <button id="btn-replay" class="btn btn--secondary" aria-label="Replay clip (R)">↺ Replay</button>
           </div>
-
           <div class="divider"></div>
-
           <div class="btn-row">
-            <button id="btn-prev" class="btn btn--ghost" aria-label="Previous segment (←)">
-              ← Prev
-            </button>
-            <button id="btn-next" class="btn btn--success" aria-label="Next segment (→)">
-              Next →
-            </button>
+            <button id="btn-prev" class="btn btn--ghost"    aria-label="Previous segment (←)">← Prev</button>
+            <button id="btn-next" class="btn btn--success"  aria-label="Next segment (→)">Next →</button>
           </div>
-
         </div>
       </div>
 
@@ -170,21 +144,10 @@
       <div class="control-panel" role="group" aria-label="Question controls">
         <div class="panel__header"><span class="panel__title">Discussion</span></div>
         <div class="panel__body">
-
-          <button id="btn-show-q" class="btn btn--secondary" aria-label="Toggle question (Q)">
-            Show Question
-          </button>
-
-          <button id="btn-backup-q" class="btn btn--ghost" aria-label="Random backup question">
-            ⚄ Random Backup Question
-          </button>
-
+          <button id="btn-show-q"    class="btn btn--secondary" aria-label="Toggle question (Q)">Show Question</button>
+          <button id="btn-backup-q"  class="btn btn--ghost"     aria-label="Random backup question">⚄ Random Backup Question</button>
           <div class="divider"></div>
-
-          <button id="btn-toggle-n" class="btn btn--ghost" aria-label="Toggle moderator notes (N)">
-            ≡ Toggle Notes
-          </button>
-
+          <button id="btn-toggle-n"  class="btn btn--ghost"     aria-label="Toggle moderator notes (N)">≡ Toggle Notes</button>
         </div>
       </div>
 
@@ -192,19 +155,19 @@
       <div class="control-panel" role="group" aria-label="Presentation controls">
         <div class="panel__header"><span class="panel__title">Presentation</span></div>
         <div class="panel__body">
+          <button id="btn-fullscreen" class="btn btn--secondary" aria-label="Fullscreen video (F)">⛶ Fullscreen Video</button>
+          <button id="btn-black"      class="btn btn--danger"    aria-label="Black screen (B)">■ Black Screen</button>
+          <button id="btn-interm"     class="btn btn--warning"   aria-label="Intermission screen (I)">☕ Intermission</button>
+        </div>
+      </div>
 
-          <button id="btn-fullscreen" class="btn btn--secondary" aria-label="Fullscreen video (F)">
-            ⛶ Fullscreen Video
+      <!-- Show Editor Launch -->
+      <div class="control-panel" role="group" aria-label="Show editor">
+        <div class="panel__header"><span class="panel__title">Show Editor</span></div>
+        <div class="panel__body">
+          <button id="btn-edit-show" class="btn btn--secondary" aria-label="Open show editor">
+            ✏ Edit Show
           </button>
-
-          <button id="btn-black" class="btn btn--danger" aria-label="Black screen (B)">
-            ■ Black Screen
-          </button>
-
-          <button id="btn-interm" class="btn btn--warning" aria-label="Intermission screen (I)">
-            ☕ Intermission
-          </button>
-
         </div>
       </div>
 
@@ -212,15 +175,15 @@
       <div class="kbd-legend" role="note" aria-label="Keyboard shortcuts">
         <div class="panel__header"><span class="panel__title">Keyboard Shortcuts</span></div>
         <div class="kbd-legend__body">
-          <div class="kbd-row"><span>Play / Pause</span>        <kbd class="kbd">Space</kbd></div>
-          <div class="kbd-row"><span>Next Segment</span>        <kbd class="kbd">→</kbd></div>
-          <div class="kbd-row"><span>Prev Segment</span>        <kbd class="kbd">←</kbd></div>
-          <div class="kbd-row"><span>Toggle Question</span>     <kbd class="kbd">Q</kbd></div>
-          <div class="kbd-row"><span>Replay Clip</span>         <kbd class="kbd">R</kbd></div>
-          <div class="kbd-row"><span>Toggle Notes</span>        <kbd class="kbd">N</kbd></div>
-          <div class="kbd-row"><span>Fullscreen</span>          <kbd class="kbd">F</kbd></div>
-          <div class="kbd-row"><span>Black Screen</span>        <kbd class="kbd">B</kbd></div>
-          <div class="kbd-row"><span>Intermission</span>        <kbd class="kbd">I</kbd></div>
+          <div class="kbd-row"><span>Play / Pause</span>    <kbd class="kbd">Space</kbd></div>
+          <div class="kbd-row"><span>Next Segment</span>    <kbd class="kbd">→</kbd></div>
+          <div class="kbd-row"><span>Prev Segment</span>    <kbd class="kbd">←</kbd></div>
+          <div class="kbd-row"><span>Toggle Question</span> <kbd class="kbd">Q</kbd></div>
+          <div class="kbd-row"><span>Replay Clip</span>     <kbd class="kbd">R</kbd></div>
+          <div class="kbd-row"><span>Toggle Notes</span>    <kbd class="kbd">N</kbd></div>
+          <div class="kbd-row"><span>Fullscreen</span>      <kbd class="kbd">F</kbd></div>
+          <div class="kbd-row"><span>Black Screen</span>    <kbd class="kbd">B</kbd></div>
+          <div class="kbd-row"><span>Intermission</span>    <kbd class="kbd">I</kbd></div>
         </div>
       </div>
 
@@ -242,22 +205,18 @@
           <span class="notes-panel__caret">▾</span>
         </button>
         <div id="notes-body" class="notes-panel__body">
-
           <div>
             <div class="notes-section__label">Panelist</div>
             <div id="notes-panelist" class="notes-section__text">—</div>
           </div>
-
           <div>
             <div class="notes-section__label">Notes</div>
             <div id="notes-text" class="notes-section__text">—</div>
           </div>
-
           <div>
             <div class="notes-section__label">Backup Questions</div>
             <ul id="notes-backup" class="notes-backup-list"></ul>
           </div>
-
         </div>
       </div>
 
@@ -266,14 +225,16 @@
   </main>
 
   <!-- ============================================================
-       SCRIPTS
-       Load clips.js first (registers onYouTubeIframeAPIReady),
-       then the YouTube IFrame API (which calls it when ready),
-       then controller.js (orchestrates everything).
+       SCRIPTS — load order matters:
+       1. clips.js   registers onYouTubeIframeAPIReady
+       2. YT API     calls onYouTubeIframeAPIReady when ready
+       3. controller.js  sets up UI + window.ShowController + fires 'showcontroller:ready'
+       4. editor.js  listens for 'showcontroller:ready' then inits
   ============================================================ -->
   <script src="clips.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
   <script src="controller.js"></script>
+  <script src="editor.js"></script>
 
 </body>
 </html>

--- a/hackertheater/styles.css
+++ b/hackertheater/styles.css
@@ -928,3 +928,619 @@ button:focus-visible {
   background: var(--border);
   margin: 2px 0;
 }
+
+/* ============================================================
+   DRAFT BANNER
+   ============================================================ */
+
+.draft-banner {
+  background: rgba(234,179,8,0.08);
+  border-bottom: 1px solid rgba(234,179,8,0.3);
+  padding: 10px 24px;
+}
+
+.draft-banner__inner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  max-width: 1400px;
+}
+
+.draft-banner__icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.draft-banner__text {
+  font-size: 0.85rem;
+  color: var(--yellow);
+  flex: 1;
+  min-width: 160px;
+}
+
+.draft-banner__btns {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.draft-banner__btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s;
+}
+
+.draft-banner__btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+
+.draft-banner__btn--primary {
+  background: rgba(234,179,8,0.15);
+  border-color: rgba(234,179,8,0.4);
+  color: var(--yellow);
+}
+
+.draft-banner__btn--primary:hover {
+  background: rgba(234,179,8,0.25);
+}
+
+.draft-banner__btn--danger {
+  color: var(--red);
+  border-color: rgba(239,68,68,0.3);
+}
+
+.draft-banner__btn--danger:hover {
+  background: rgba(239,68,68,0.12);
+}
+
+/* ============================================================
+   SHOW EDITOR MODAL
+   ============================================================ */
+
+.editor-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 250;
+  background: rgba(0,0,0,0.75);
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  animation: fadeIn 0.15s ease;
+}
+
+.editor-modal.active {
+  display: flex;
+}
+
+.editor-modal__inner {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1160px;
+  max-height: 90vh;
+  overflow: hidden;
+}
+
+/* ---- Modal Header ---- */
+
+.editor-modal__header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 14px 20px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.editor-modal__header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.editor-modal__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+.ed-unsaved-dot {
+  color: var(--yellow);
+  font-size: 0.8rem;
+}
+
+.editor-modal__meta {
+  display: flex;
+  gap: 12px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.ed-meta-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ed-meta-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.ed-meta-input {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.9rem;
+  padding: 5px 10px;
+  min-width: 180px;
+  transition: border-color 0.15s;
+}
+
+.ed-meta-input:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+.editor-modal__close {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font-size: 1rem;
+  padding: 5px 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-left: auto;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.editor-modal__close:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+/* ---- Modal Body ---- */
+
+.editor-modal__body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* ---- Segment List Panel (left) ---- */
+
+.ed-list-panel {
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  background: var(--bg-primary);
+}
+
+.ed-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.ed-list-header__title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.ed-seg-count {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.ed-add-btn {
+  padding: 5px 12px;
+  font-size: 0.8rem;
+}
+
+.ed-seg-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.ed-list-empty {
+  padding: 24px 16px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.ed-seg-item {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+
+.ed-seg-item:hover {
+  border-color: var(--text-muted);
+}
+
+.ed-seg-item--active {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.ed-seg-item__reorder {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.ed-icon-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 6px 7px;
+  line-height: 1;
+  transition: color 0.15s, background 0.15s;
+  font-family: inherit;
+}
+
+.ed-icon-btn:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.ed-icon-btn:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+
+.ed-icon-btn--preview { color: var(--accent); }
+.ed-icon-btn--preview:hover:not(:disabled) { color: var(--accent-hover); }
+
+.ed-icon-btn--delete  { color: var(--red); }
+.ed-icon-btn--delete:hover:not(:disabled) { background: rgba(239,68,68,0.12); }
+
+.ed-seg-item__body {
+  flex: 1;
+  padding: 9px 10px;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.ed-seg-item__num {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+  font-family: var(--font-mono);
+}
+
+.ed-seg-item--active .ed-seg-item__num { color: var(--accent); }
+
+.ed-seg-item__title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ed-seg-item__meta {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ed-seg-item__actions {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* ---- Form Panel (right) ---- */
+
+.ed-form-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.ed-form-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 40px;
+  line-height: 1.6;
+}
+
+.ed-form-empty__icon {
+  font-size: 2rem;
+  opacity: 0.3;
+}
+
+.ed-form-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.ed-form-heading {
+  padding: 10px 20px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.ed-form-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.ed-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.ed-field-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.ed-field-row .ed-field {
+  flex: 1;
+}
+
+.ed-field--narrow {
+  flex: 0 0 110px !important;
+}
+
+.ed-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+}
+
+.ed-required {
+  color: var(--accent);
+  margin-left: 1px;
+}
+
+.ed-label-hint {
+  font-weight: 400;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.ed-input,
+.ed-textarea {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.9rem;
+  padding: 8px 12px;
+  width: 100%;
+  transition: border-color 0.15s;
+  resize: none;
+}
+
+.ed-input:focus,
+.ed-textarea:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+.ed-textarea {
+  resize: vertical;
+  min-height: 60px;
+  line-height: 1.5;
+}
+
+.ed-field-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+/* Validation errors block */
+
+.ed-validation-errors {
+  background: rgba(239,68,68,0.08);
+  border: 1px solid rgba(239,68,68,0.3);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.ed-error-item {
+  font-size: 0.82rem;
+  color: var(--red);
+  line-height: 1.4;
+}
+
+/* Form footer */
+
+.ed-form-footer {
+  display: flex;
+  gap: 8px;
+  padding: 12px 20px;
+  background: var(--bg-elevated);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.ed-form-footer .btn {
+  width: auto;
+  flex: 0 0 auto;
+  padding: 8px 16px;
+  font-size: 0.85rem;
+}
+
+.ed-delete-btn {
+  margin-left: auto !important;
+}
+
+/* ---- Modal Footer ---- */
+
+.editor-modal__footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  background: var(--bg-elevated);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.editor-modal__footer .btn {
+  width: auto;
+  flex: 0 0 auto;
+  padding: 9px 16px;
+  font-size: 0.85rem;
+}
+
+.ed-close-btn {
+  margin-left: auto !important;
+}
+
+/* Import label styled as a button */
+
+.ed-import-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* ============================================================
+   RESPONSIVE — editor
+   ============================================================ */
+
+@media (max-width: 860px) {
+  .editor-modal__body {
+    flex-direction: column;
+  }
+
+  .ed-list-panel {
+    width: 100%;
+    max-height: 220px;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .ed-seg-list {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: 6px;
+  }
+
+  .ed-seg-item {
+    min-width: 180px;
+    flex-direction: column;
+  }
+
+  .ed-seg-item__reorder {
+    flex-direction: row;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .ed-seg-item__actions {
+    flex-direction: row;
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 600px) {
+  .editor-modal { padding: 0; }
+  .editor-modal__inner { border-radius: 0; max-height: 100vh; }
+  .ed-field-row { flex-direction: column; }
+  .ed-field--narrow { flex: 1 !important; }
+  .editor-modal__footer { gap: 6px; }
+  .editor-modal__footer .btn { padding: 8px 10px; font-size: 0.78rem; }
+}


### PR DESCRIPTION
Adds editor.js (new) and updates controller.js, index.html, styles.css. No backend, no dependencies, no eval, fully static.

Features:
- "Edit Show" button in control panel opens modal editor
- Segment list: add, edit, delete, move up/down, preview
- Form: title, YouTube URL (auto-parses all URL formats), start/end (accepts seconds / mm:ss / hh:mm:ss), panelist, question, backups, notes, discussion minutes
- Validation with inline error messages
- Save Draft → localStorage (key: charlestonhacks.hackertheater.showDraft.v1)
- Draft banner on page load with Use Draft / Use Published / Clear Draft
- Apply & Close → replaces running show + refreshes queue
- Export show.json → pretty-printed download
- Import show.json → reads local file, validates, loads into editor
- Reset to Published → restores original show.json data
- Keyboard shortcuts suppressed while editor is open
- controller.js exposes window.ShowController with getShow, getPublishedShow, replaceShow, previewSegment, jumpToSegment
- 'showcontroller:ready' event coordinates initialization order

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i