### PR TITLE
Add projector display mode to Hacker Theater

### DIFF
--- a/hackertheater/channel.js
+++ b/hackertheater/channel.js
@@ -1,0 +1,79 @@
+/**
+ * channel.js — BroadcastChannel + localStorage bridge
+ *
+ * Provides a unified messaging layer for control room → projector sync.
+ * BroadcastChannel is used when both windows are open simultaneously.
+ * localStorage is used to persist state so a projector opened after the
+ * show started can still restore the current state.
+ *
+ * Channel name:  'hackertheater-projector'
+ * Storage key:   'charlestonhacks.hackertheater.projectorState.v1'
+ */
+
+const Channel = (() => {
+  const CHANNEL_NAME = 'hackertheater-projector';
+  const LS_KEY       = 'charlestonhacks.hackertheater.projectorState.v1';
+
+  let bc        = null;
+  let _handlers = {};   // { messageType: [fn, ...] }
+
+  // ---- Init BroadcastChannel (safe — not supported in all browsers) ----
+
+  try {
+    bc = new BroadcastChannel(CHANNEL_NAME);
+    bc.onmessage = (ev) => {
+      const { type, payload } = ev.data || {};
+      if (type) _dispatch(type, payload);
+    };
+  } catch (e) {
+    console.warn('[Channel] BroadcastChannel unavailable — sync is localStorage-only.');
+  }
+
+  function _dispatch(type, payload) {
+    const fns = _handlers[type] || [];
+    fns.forEach(fn => { try { fn(payload); } catch (e) { console.warn('[Channel] handler error', type, e); } });
+
+    // Also fire wildcard listeners
+    (_handlers['*'] || []).forEach(fn => { try { fn(type, payload); } catch {} });
+  }
+
+  // ---- Public API ----
+
+  /** Send a typed message to any other open windows. Does NOT save to LS. */
+  function send(type, payload) {
+    if (!bc) return;
+    try { bc.postMessage({ type, payload: payload || {} }); } catch (e) {
+      console.warn('[Channel] send error:', e.message);
+    }
+  }
+
+  /** Register a handler for a message type. Use '*' to catch all types. */
+  function on(type, fn) {
+    if (!_handlers[type]) _handlers[type] = [];
+    _handlers[type].push(fn);
+  }
+
+  /** Persist full state snapshot to localStorage (survives page reload). */
+  function saveState(snapshot) {
+    try {
+      localStorage.setItem(LS_KEY, JSON.stringify({ ...snapshot, _savedAt: Date.now() }));
+    } catch (e) {
+      console.warn('[Channel] saveState error:', e.message);
+    }
+  }
+
+  /** Retrieve the last saved state, or null if none. */
+  function loadState() {
+    try {
+      const raw = localStorage.getItem(LS_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch { return null; }
+  }
+
+  /** Remove saved state (e.g., at show end). */
+  function clearState() {
+    try { localStorage.removeItem(LS_KEY); } catch {}
+  }
+
+  return { send, on, saveState, loadState, clearState };
+})();

--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -206,6 +206,8 @@
     refreshQueue();
     setStatus('paused', 'Ready — press Play');
 
+    _broadcast('loadSegment', { index, segment: seg, totalSegments: segments.length });
+
     if (autoPlay) setTimeout(() => playClip(), 300);
   }
 
@@ -215,7 +217,89 @@
   }
 
   // ============================================================
-  // 7. REPLACE SHOW (called by editor.js via ShowController)
+  // 7. PROJECTOR CHANNEL
+  // ============================================================
+
+  let _lastTimerSave    = 0;
+  let _lastProjectorPing = 0;
+
+  function _buildSnapshot() {
+    const seg = segments[currentIndex] || null;
+    return {
+      show:            { ...show, segments },
+      segmentIndex:    currentIndex,
+      totalSegments:   segments.length,
+      segment:         seg,
+      videoId:         seg ? seg.youtubeId : null,
+      videoStart:      seg ? (seg.start || 0) : 0,
+      videoEnd:        seg ? (seg.end   || 0) : 0,
+      playbackState:   Clips.isPlaying() ? 'playing' : 'paused',
+      questionVisible: state.questionVisible,
+      questionText:    dom.questionText ? dom.questionText.textContent : null,
+      timerTotal:      state.timerTotal,
+      timerRemaining:  state.timerRemaining,
+      timerRunning:    state.timerRunning,
+      overlay:         state.blackActive ? 'black' : (state.intermActive ? 'intermission' : 'none'),
+    };
+  }
+
+  function _broadcast(type, payload) {
+    if (typeof Channel === 'undefined') return;
+    Channel.send(type, payload || {});
+    // Save state on all messages except high-frequency timer ticks
+    // (for those, throttle to once per 5 seconds)
+    if (type !== 'updateTimer') {
+      Channel.saveState(_buildSnapshot());
+    } else if (Date.now() - _lastTimerSave > 5000) {
+      _lastTimerSave = Date.now();
+      Channel.saveState(_buildSnapshot());
+    }
+  }
+
+  // Listen for messages from the projector display
+  if (typeof Channel !== 'undefined') {
+    Channel.on('requestSync', () => {
+      Channel.send('fullSync', _buildSnapshot());
+      Channel.saveState(_buildSnapshot());
+      _updateProjectorStatus(true);
+    });
+
+    Channel.on('ping', () => {
+      _lastProjectorPing = Date.now();
+      Channel.send('pong');
+      _updateProjectorStatus(true);
+    });
+
+    Channel.on('pong', () => {
+      _lastProjectorPing = Date.now();
+      _updateProjectorStatus(true);
+    });
+
+    // Send periodic heartbeat so display.js knows control room is alive
+    setInterval(() => {
+      Channel.send('heartbeat');
+      // Check whether projector has gone silent
+      if (_lastProjectorPing > 0 && Date.now() - _lastProjectorPing > 10000) {
+        _updateProjectorStatus(false);
+      }
+    }, 5000);
+  }
+
+  function _updateProjectorStatus(connected) {
+    const dot   = $('proj-dot');
+    const label = $('proj-label');
+    if (!dot || !label) return;
+    if (connected) {
+      dot.className   = 'proj-dot proj-dot--connected';
+      label.textContent = 'Projector connected';
+    } else {
+      dot.className   = 'proj-dot';
+      label.textContent = 'Projector not connected';
+    }
+  }
+
+  // ============================================================
+  // 8. REPLACE SHOW (called by editor.js via ShowController)
   // ============================================================
 
   function replaceShow(newShow) {
@@ -237,6 +321,7 @@
     } else {
       setStatus('paused', 'No segments loaded');
     }
+    _broadcast('applyShowData', { show });
   }
 
   // ============================================================
@@ -255,11 +340,13 @@
     // updates the status indicator when PLAYING fires.
     Clips.play(seg.youtubeId, seg.start || 0, seg.end || 0);
     setStatus('playing', 'Loading…');
+    _broadcast('play', { videoId: seg.youtubeId, start: seg.start || 0, end: seg.end || 0 });
   }
 
   function pauseClip() {
     Clips.pause();
     setStatus('paused', 'Paused');
+    _broadcast('pause');
   }
 
   function replayClip() {
@@ -267,6 +354,7 @@
     if (!seg || !seg.youtubeId) return;
     Clips.replay(seg.start || 0, seg.end || 0);
     setStatus('playing', 'Replaying');
+    _broadcast('replay', { start: seg.start || 0, end: seg.end || 0 });
   }
 
   function prevSegment() {
@@ -287,6 +375,7 @@
     dom.questionCard.classList.add('revealed');
     dom.questionText.classList.remove('hidden-text');
     $('btn-show-q').textContent = 'Hide Question';
+    _broadcast('showQuestion', { text: dom.questionText.textContent });
   }
 
   function hideQuestionCard() {
@@ -294,6 +383,7 @@
     dom.questionCard.classList.remove('revealed');
     dom.questionText.classList.add('hidden-text');
     $('btn-show-q').textContent = 'Show Question';
+    _broadcast('hideQuestion');
   }
 
   function toggleQuestion() {
@@ -319,6 +409,7 @@
     if (state.timerRunning) return;
     state.timerRunning = true;
     state.timerHandle  = setInterval(tickTimer, 1000);
+    _broadcast('startDiscussionTimer', { total: state.timerTotal, remaining: state.timerRemaining });
   }
 
   function pauseTimer() {
@@ -342,10 +433,12 @@
     if (state.timerRemaining <= 0) {
       pauseTimer();
       renderTimer(0, state.timerTotal);
+      _broadcast('updateTimer', { total: state.timerTotal, remaining: 0, running: false });
       return;
     }
     state.timerRemaining -= 1;
     renderTimer(state.timerRemaining, state.timerTotal);
+    _broadcast('updateTimer', { total: state.timerTotal, remaining: state.timerRemaining, running: true });
   }
 
   function renderTimer(remaining, total) {
@@ -374,11 +467,13 @@
     state.blackActive = true;
     dom.blackOverlay.classList.add('active');
     if (Clips.isPlaying()) Clips.pause();
+    _broadcast('blackScreen');
   }
 
   function deactivateBlack() {
     state.blackActive = false;
     dom.blackOverlay.classList.remove('active');
+    _broadcast('clearOverlay');
   }
 
   function activateIntermission() {
@@ -387,12 +482,14 @@
     if (Clips.isPlaying()) Clips.pause();
     updateIntermClock();
     state.intermClockHandle = setInterval(updateIntermClock, 1000);
+    _broadcast('intermission');
   }
 
   function deactivateIntermission() {
     state.intermActive = false;
     dom.intermOverlay.classList.remove('active');
     clearInterval(state.intermClockHandle);
+    _broadcast('clearOverlay');
   }
 
   function updateIntermClock() {
@@ -511,6 +608,9 @@
   wireBtn('btn-timer-start', startTimer);
   wireBtn('btn-timer-pause', pauseTimer);
   wireBtn('btn-timer-reset', resetTimer);
+  wireBtn('btn-projector', () => {
+    window.open('./display.html', 'hackertheater-projector', 'noopener');
+  });
 
   // ============================================================
   // 17. TOAST / ERROR

--- a/hackertheater/display.html
+++ b/hackertheater/display.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hacker Theater — Projector Display · CharlestonHacks</title>
+  <meta name="robots" content="noindex, nofollow" />
+  <style>
+    /* ---- Reset ---- */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:       #0d0d0f;
+      --bg2:      #15151a;
+      --bg3:      #1c1c24;
+      --border:   #2e2e3e;
+      --accent:   #6c63ff;
+      --green:    #22c55e;
+      --yellow:   #eab308;
+      --orange:   #f97316;
+      --red:      #ef4444;
+      --text:     #f0f0f5;
+      --text2:    #9898b0;
+      --text3:    #5c5c72;
+      --mono:     'Courier New', Courier, monospace;
+      --sans:     -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    }
+
+    html, body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+      height: 100%;
+      overflow: hidden;
+    }
+
+    /* ---- Overlays (black screen / intermission) ---- */
+    .overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 28px;
+    }
+    .overlay.active { display: flex; }
+
+    .overlay--black { background: #000; }
+    .overlay--intermission { background: var(--bg); }
+
+    .overlay__logo {
+      width: clamp(160px, 30vw, 340px);
+      opacity: 0.9;
+    }
+    .overlay__title {
+      font-size: clamp(3rem, 8vw, 6rem);
+      font-weight: 800;
+      letter-spacing: 0.05em;
+    }
+    .overlay__subtitle {
+      font-size: clamp(1rem, 2.5vw, 1.8rem);
+      color: var(--text2);
+    }
+    .overlay__clock {
+      font-family: var(--mono);
+      font-size: clamp(1.6rem, 3.5vw, 2.6rem);
+      color: var(--accent);
+      letter-spacing: 0.12em;
+    }
+
+    /* ---- Main layout ---- */
+    .display {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    /* ---- Header strip ---- */
+    .disp-header {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      padding: 10px 28px;
+      background: var(--bg2);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .disp-header__logo {
+      height: 32px;
+      flex-shrink: 0;
+    }
+    .disp-header__event {
+      flex: 1;
+      font-size: clamp(0.9rem, 1.8vw, 1.15rem);
+      font-weight: 700;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .disp-header__seg {
+      font-size: clamp(0.75rem, 1.2vw, 0.9rem);
+      color: var(--text2);
+      font-family: var(--mono);
+      white-space: nowrap;
+    }
+
+    /* ---- Connection pill (auto-fades when connected) ---- */
+    .conn-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.72rem;
+      color: var(--text3);
+      padding: 3px 9px;
+      border: 1px solid var(--border);
+      border-radius: 99px;
+      flex-shrink: 0;
+      transition: opacity 0.5s;
+    }
+    .conn-pill.connected { opacity: 0; pointer-events: none; }
+    .conn-pill__dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--text3);
+      flex-shrink: 0;
+    }
+    .conn-pill.connected .conn-pill__dot { background: var(--green); }
+    .conn-pill.connecting .conn-pill__dot { background: var(--yellow); }
+    .conn-pill.disconnected .conn-pill__dot { background: var(--red); }
+
+    /* ---- Body: video + info ---- */
+    .disp-body {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      padding: 16px 20px 10px;
+      gap: 12px;
+    }
+
+    /* Video sized to fill available height while keeping 16:9 */
+    .video-wrap {
+      flex-shrink: 0;
+      width: 100%;
+      max-width: calc((100vh - 220px) * (16/9));
+      aspect-ratio: 16/9;
+      align-self: center;
+      position: relative;
+      background: #000;
+      border-radius: 10px;
+      overflow: hidden;
+    }
+    #yt-player {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+    .video-placeholder {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      background: var(--bg3);
+      color: var(--text3);
+    }
+    .video-placeholder__icon { font-size: 2.5rem; opacity: 0.35; }
+    .video-placeholder.hidden { display: none; }
+
+    /* ---- Segment info strip ---- */
+    .seg-info {
+      flex-shrink: 0;
+      display: flex;
+      align-items: baseline;
+      gap: 14px;
+      min-height: 0;
+    }
+    .seg-info__title {
+      font-size: clamp(1rem, 2.2vw, 1.55rem);
+      font-weight: 700;
+      color: var(--text);
+      line-height: 1.25;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .seg-info__panelist {
+      font-size: clamp(0.75rem, 1.3vw, 1rem);
+      color: var(--accent);
+      font-weight: 600;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    /* ---- Question card ---- */
+    .question-card {
+      flex-shrink: 0;
+      background: var(--bg3);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      overflow: hidden;
+      transition: border-color 0.3s, opacity 0.3s;
+    }
+    .question-card.revealed { border-color: var(--accent); }
+    .question-card__label {
+      padding: 8px 16px;
+      background: var(--bg2);
+      border-bottom: 1px solid var(--border);
+      font-size: 0.68rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text3);
+    }
+    .question-card__text {
+      padding: 14px 20px;
+      font-size: clamp(1rem, 2vw, 1.5rem);
+      font-weight: 600;
+      color: var(--text);
+      line-height: 1.4;
+      transition: filter 0.3s;
+    }
+    .question-card__text.blurred {
+      filter: blur(8px);
+      user-select: none;
+    }
+
+    /* ---- Discussion timer ---- */
+    .timer-strip {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 14px;
+    }
+    .timer-strip__label {
+      font-size: clamp(0.7rem, 1.2vw, 0.82rem);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text2);
+      flex-shrink: 0;
+    }
+    .timer__bar-wrap {
+      flex: 1;
+      height: 6px;
+      background: var(--border);
+      border-radius: 99px;
+      overflow: hidden;
+    }
+    .timer__bar {
+      height: 100%;
+      background: var(--green);
+      border-radius: 99px;
+      transition: width 1s linear, background 0.3s;
+      width: 100%;
+    }
+    .timer__bar.warn-60 { background: var(--yellow); }
+    .timer__bar.warn-30 { background: var(--orange); }
+    .timer__bar.warn-0  { background: var(--red); }
+    .timer__display {
+      font-family: var(--mono);
+      font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+      font-weight: 700;
+      color: var(--green);
+      letter-spacing: 0.05em;
+      min-width: 80px;
+      text-align: right;
+      flex-shrink: 0;
+      transition: color 0.3s;
+    }
+    .timer__display.warn-60 { color: var(--yellow); }
+    .timer__display.warn-30 { color: var(--orange); }
+    .timer__display.warn-0  { color: var(--red); animation: pulse 0.8s infinite; }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.45; }
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Black screen overlay -->
+  <div id="black-overlay" class="overlay overlay--black">
+    <img src="/charlestonhackslogo.svg" alt="CharlestonHacks" class="overlay__logo" onerror="this.style.display='none'" />
+  </div>
+
+  <!-- Intermission overlay -->
+  <div id="interm-overlay" class="overlay overlay--intermission">
+    <img src="/charlestonhackslogo.svg" alt="CharlestonHacks" class="overlay__logo" onerror="this.style.display='none'" />
+    <div class="overlay__title">INTERMISSION</div>
+    <div class="overlay__subtitle">Returning Shortly</div>
+    <div id="interm-clock" class="overlay__clock"></div>
+  </div>
+
+  <!-- Main display -->
+  <div class="display">
+
+    <header class="disp-header">
+      <img src="/charlestonhackslogo.svg" alt="CharlestonHacks" class="disp-header__logo" onerror="this.style.display='none'" />
+      <div id="event-name" class="disp-header__event">Hacker Theater</div>
+      <div id="seg-counter" class="disp-header__seg">—</div>
+      <div id="conn-pill" class="conn-pill connecting">
+        <div class="conn-pill__dot"></div>
+        <span id="conn-label">Connecting…</span>
+      </div>
+    </header>
+
+    <div class="disp-body">
+
+      <div class="video-wrap">
+        <div id="yt-player"></div>
+        <div id="video-placeholder" class="video-placeholder">
+          <div class="video-placeholder__icon">▶</div>
+        </div>
+      </div>
+
+      <div class="seg-info">
+        <div id="seg-title" class="seg-info__title">—</div>
+        <div id="seg-panelist" class="seg-info__panelist"></div>
+      </div>
+
+      <div id="question-card" class="question-card">
+        <div class="question-card__label">Discussion Question</div>
+        <div id="question-text" class="question-card__text blurred">—</div>
+      </div>
+
+      <div class="timer-strip">
+        <div class="timer-strip__label">Discussion</div>
+        <div class="timer__bar-wrap">
+          <div id="timer-bar" class="timer__bar"></div>
+        </div>
+        <div id="timer-display" class="timer__display">—:——</div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Scripts: channel first, then display logic, then YT API -->
+  <script src="channel.js"></script>
+  <script src="display.js"></script>
+  <script src="https://www.youtube.com/iframe_api"></script>
+
+</body>
+</html>

--- a/hackertheater/display.js
+++ b/hackertheater/display.js
@@ -1,0 +1,400 @@
+/**
+ * display.js — Projector display logic
+ *
+ * Maintains its own YouTube player and responds to Channel messages
+ * from the control room. On load, restores state from localStorage,
+ * then sends requestSync to get a live update if the control room
+ * is also open.
+ */
+
+(function () {
+
+  // ---- DOM refs ----
+  const $ = id => document.getElementById(id);
+
+  const dom = {
+    eventName:    $('event-name'),
+    segCounter:   $('seg-counter'),
+    connPill:     $('conn-pill'),
+    connLabel:    $('conn-label'),
+    blackOverlay: $('black-overlay'),
+    intermOverlay:$('interm-overlay'),
+    intermClock:  $('interm-clock'),
+    placeholder:  $('video-placeholder'),
+    segTitle:     $('seg-title'),
+    segPanelist:  $('seg-panelist'),
+    questionCard: $('question-card'),
+    questionText: $('question-text'),
+    timerDisplay: $('timer-display'),
+    timerBar:     $('timer-bar'),
+  };
+
+  // ---- YouTube player ----
+
+  let player      = null;
+  let playerReady = false;
+  let pendingVideoAction = null;   // queued until playerReady
+
+  window.onYouTubeIframeAPIReady = () => {
+    try {
+      player = new YT.Player('yt-player', {
+        height: '100%',
+        width:  '100%',
+        playerVars: {
+          autoplay:       0,
+          controls:       0,
+          rel:            0,
+          modestbranding: 1,
+          fs:             0,
+          iv_load_policy: 3,
+          cc_load_policy: 0,
+          disablekb:      1,
+        },
+        events: {
+          onReady: _onPlayerReady,
+          onError: _onPlayerError,
+        },
+      });
+    } catch (e) {
+      console.warn('[Display] Failed to create YT.Player:', e.message);
+    }
+  };
+
+  function _onPlayerReady() {
+    playerReady = true;
+    dom.placeholder.classList.add('hidden');
+    if (pendingVideoAction) {
+      const a = pendingVideoAction;
+      pendingVideoAction = null;
+      try { a(); } catch (e) { console.warn('[Display] pending action threw:', e.message); }
+    }
+  }
+
+  function _onPlayerError(ev) {
+    console.warn('[Display] YT player error:', ev.data);
+  }
+
+  function _execVideo(fn) {
+    if (!player) return;
+    if (!playerReady) { pendingVideoAction = fn; return; }
+    try { fn(); } catch (e) { console.warn('[Display] player action threw:', e.message); }
+  }
+
+  // ---- Timer ----
+
+  const timer = {
+    total:     0,
+    remaining: 0,
+    running:   false,
+    handle:    null,
+  };
+
+  function _startTimer(total, remaining) {
+    _stopTimer();
+    timer.total     = total;
+    timer.remaining = remaining;
+    timer.running   = true;
+    timer.handle    = setInterval(_tickTimer, 1000);
+    _renderTimer();
+  }
+
+  function _stopTimer() {
+    timer.running = false;
+    clearInterval(timer.handle);
+    timer.handle = null;
+  }
+
+  function _tickTimer() {
+    if (!timer.running) return;
+    if (timer.remaining <= 0) { _stopTimer(); _renderTimer(); return; }
+    timer.remaining -= 1;
+    _renderTimer();
+  }
+
+  function _renderTimer() {
+    const r = timer.remaining;
+    const t = timer.total;
+    if (t === 0 && r === 0) { dom.timerDisplay.textContent = '—:——'; dom.timerBar.style.width = '100%'; return; }
+
+    const m = Math.floor(r / 60);
+    const s = r % 60;
+    dom.timerDisplay.textContent = `${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
+    dom.timerBar.style.width = `${t > 0 ? (r / t) * 100 : 0}%`;
+
+    for (const el of [dom.timerDisplay, dom.timerBar]) {
+      el.classList.remove('warn-60','warn-30','warn-0');
+      if      (r === 0)  el.classList.add('warn-0');
+      else if (r <= 30)  el.classList.add('warn-30');
+      else if (r <= 60)  el.classList.add('warn-60');
+    }
+  }
+
+  // ---- Connection status ----
+
+  let _lastActivity = 0;
+  let _connCheckHandle = null;
+
+  function _setConnected(label) {
+    dom.connPill.className   = 'conn-pill connected';
+    dom.connLabel.textContent = label || 'Synced';
+    _lastActivity = Date.now();
+  }
+
+  function _setConnecting() {
+    dom.connPill.className    = 'conn-pill connecting';
+    dom.connLabel.textContent = 'Connecting…';
+  }
+
+  function _setDisconnected() {
+    dom.connPill.className    = 'conn-pill disconnected';
+    dom.connLabel.textContent = 'No control room';
+  }
+
+  function _noteActivity() {
+    _lastActivity = Date.now();
+    _setConnected('Live');
+  }
+
+  // Periodically check if we've heard from the control room recently
+  _connCheckHandle = setInterval(() => {
+    if (_lastActivity === 0) return; // still waiting for first sync
+    const age = Date.now() - _lastActivity;
+    if (age > 12000) _setDisconnected();       // >12s
+    else if (age > 6000) _setConnecting();     // >6s
+    else _setConnected('Live');
+  }, 2000);
+
+  // ---- Intermission clock ----
+
+  let _intermHandle = null;
+  function _startIntermClock() {
+    _updateIntermClock();
+    _intermHandle = setInterval(_updateIntermClock, 1000);
+  }
+  function _stopIntermClock() { clearInterval(_intermHandle); }
+  function _updateIntermClock() {
+    dom.intermClock.textContent = new Date().toLocaleTimeString([], {
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
+  }
+
+  // ---- Apply full snapshot (from localStorage or fullSync message) ----
+
+  function applyFullSync(snap) {
+    if (!snap) return;
+
+    // Event info
+    if (snap.show) {
+      dom.eventName.textContent = snap.show.eventName || 'Hacker Theater';
+    }
+
+    // Segment info
+    const seg = snap.segment;
+    if (seg) {
+      dom.segTitle.textContent    = seg.title    || '—';
+      dom.segPanelist.textContent = seg.panelist ? `↳ ${seg.panelist}` : '';
+    }
+    if (snap.segmentIndex != null && snap.totalSegments) {
+      dom.segCounter.textContent = `${snap.segmentIndex + 1} / ${snap.totalSegments}`;
+    }
+
+    // Question
+    if (snap.questionText) {
+      dom.questionText.textContent = snap.questionText;
+    }
+    if (snap.questionVisible) {
+      dom.questionCard.classList.add('revealed');
+      dom.questionText.classList.remove('blurred');
+    } else {
+      dom.questionCard.classList.remove('revealed');
+      dom.questionText.classList.add('blurred');
+    }
+
+    // Timer
+    if (snap.timerTotal != null) {
+      timer.total     = snap.timerTotal;
+      timer.remaining = snap.timerRemaining != null ? snap.timerRemaining : snap.timerTotal;
+      _stopTimer();
+      if (snap.timerRunning) {
+        timer.running = true;
+        timer.handle  = setInterval(_tickTimer, 1000);
+      }
+      _renderTimer();
+    }
+
+    // Overlay
+    if (snap.overlay === 'black') {
+      _activateBlack();
+    } else if (snap.overlay === 'intermission') {
+      _activateIntermission();
+    } else {
+      _clearOverlays();
+    }
+
+    // Video
+    if (snap.videoId) {
+      _execVideo(() => {
+        if (snap.playbackState === 'playing') {
+          player.loadVideoById({ videoId: snap.videoId, startSeconds: snap.videoStart || 0 });
+        } else {
+          player.cueVideoById({ videoId: snap.videoId, startSeconds: snap.videoStart || 0 });
+        }
+      });
+    }
+  }
+
+  // ---- Overlay helpers ----
+
+  function _activateBlack() {
+    dom.blackOverlay.classList.add('active');
+    dom.intermOverlay.classList.remove('active');
+    _stopIntermClock();
+  }
+
+  function _activateIntermission() {
+    dom.intermOverlay.classList.add('active');
+    dom.blackOverlay.classList.remove('active');
+    _startIntermClock();
+  }
+
+  function _clearOverlays() {
+    dom.blackOverlay.classList.remove('active');
+    dom.intermOverlay.classList.remove('active');
+    _stopIntermClock();
+  }
+
+  // ---- Channel message handlers ----
+
+  Channel.on('loadSegment', (p) => {
+    _noteActivity();
+    const seg = p.segment || {};
+    dom.segTitle.textContent    = seg.title    || '—';
+    dom.segPanelist.textContent = seg.panelist ? `↳ ${seg.panelist}` : '';
+    if (p.index != null && p.totalSegments) {
+      dom.segCounter.textContent = `${p.index + 1} / ${p.totalSegments}`;
+    }
+    // Reset question
+    dom.questionCard.classList.remove('revealed');
+    dom.questionText.classList.add('blurred');
+    if (seg.question) dom.questionText.textContent = seg.question;
+
+    // Reset timer display
+    _stopTimer();
+    timer.total = timer.remaining = 0;
+    _renderTimer();
+
+    // Cue the video without playing
+    if (seg.youtubeId) {
+      _execVideo(() => {
+        player.cueVideoById({ videoId: seg.youtubeId, startSeconds: seg.start || 0 });
+      });
+    }
+  });
+
+  Channel.on('play', (p) => {
+    _noteActivity();
+    if (!p.videoId) return;
+    _execVideo(() => {
+      player.loadVideoById({ videoId: p.videoId, startSeconds: p.start || 0 });
+    });
+  });
+
+  Channel.on('pause', () => {
+    _noteActivity();
+    if (playerReady) try { player.pauseVideo(); } catch {}
+  });
+
+  Channel.on('replay', (p) => {
+    _noteActivity();
+    if (!playerReady) return;
+    try {
+      player.seekTo(p.start || 0, true);
+      player.playVideo();
+    } catch (e) { console.warn('[Display] replay error:', e.message); }
+  });
+
+  Channel.on('showQuestion', (p) => {
+    _noteActivity();
+    if (p.text) dom.questionText.textContent = p.text;
+    dom.questionCard.classList.add('revealed');
+    dom.questionText.classList.remove('blurred');
+  });
+
+  Channel.on('hideQuestion', () => {
+    _noteActivity();
+    dom.questionCard.classList.remove('revealed');
+    dom.questionText.classList.add('blurred');
+  });
+
+  Channel.on('startDiscussionTimer', (p) => {
+    _noteActivity();
+    _startTimer(p.total || 0, p.remaining != null ? p.remaining : p.total || 0);
+  });
+
+  Channel.on('updateTimer', (p) => {
+    _noteActivity();
+    timer.total     = p.total != null ? p.total : timer.total;
+    timer.remaining = p.remaining != null ? p.remaining : timer.remaining;
+    _stopTimer();
+    if (p.running !== false) {
+      timer.running = true;
+      timer.handle  = setInterval(_tickTimer, 1000);
+    }
+    _renderTimer();
+  });
+
+  Channel.on('blackScreen', () => {
+    _noteActivity();
+    _activateBlack();
+    if (playerReady) try { player.pauseVideo(); } catch {}
+  });
+
+  Channel.on('intermission', () => {
+    _noteActivity();
+    _activateIntermission();
+    if (playerReady) try { player.pauseVideo(); } catch {}
+  });
+
+  Channel.on('clearOverlay', () => {
+    _noteActivity();
+    _clearOverlays();
+  });
+
+  Channel.on('applyShowData', (p) => {
+    _noteActivity();
+    if (p && p.show) {
+      dom.eventName.textContent = p.show.eventName || 'Hacker Theater';
+    }
+  });
+
+  Channel.on('fullSync', (snap) => {
+    _noteActivity();
+    applyFullSync(snap);
+  });
+
+  Channel.on('heartbeat', () => {
+    _noteActivity();
+    // Reply so the control room knows the projector is alive
+    Channel.send('ping');
+  });
+
+  Channel.on('pong', () => {
+    _noteActivity();
+  });
+
+  // ---- Boot ----
+
+  // 1. Restore from localStorage (covers the case where display opens mid-show)
+  const saved = Channel.loadState();
+  if (saved) {
+    applyFullSync(saved);
+    _setConnecting();
+  }
+
+  // 2. Ask the control room for a live sync
+  Channel.send('requestSync');
+
+  // 3. Periodic ping so the control room can track connection
+  setInterval(() => Channel.send('ping'), 4000);
+
+})();

--- a/hackertheater/index.html
+++ b/hackertheater/index.html
@@ -171,6 +171,20 @@
         </div>
       </div>
 
+      <!-- Projector Display -->
+      <div class="control-panel" role="group" aria-label="Projector display">
+        <div class="panel__header"><span class="panel__title">Projector</span></div>
+        <div class="panel__body">
+          <button id="btn-projector" class="btn btn--secondary" aria-label="Open projector display">
+            ⬛ Open Projector View
+          </button>
+          <div class="proj-status" id="proj-status">
+            <div id="proj-dot" class="proj-dot"></div>
+            <span id="proj-label">Projector not connected</span>
+          </div>
+        </div>
+      </div>
+
       <!-- Keyboard Shortcut Legend -->
       <div class="kbd-legend" role="note" aria-label="Keyboard shortcuts">
         <div class="panel__header"><span class="panel__title">Keyboard Shortcuts</span></div>
@@ -231,6 +245,7 @@
        3. controller.js  sets up UI + window.ShowController + fires 'showcontroller:ready'
        4. editor.js  listens for 'showcontroller:ready' then inits
   ============================================================ -->
+  <script src="channel.js"></script>
   <script src="clips.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
   <script src="controller.js"></script>

--- a/hackertheater/styles.css
+++ b/hackertheater/styles.css
@@ -1544,3 +1544,30 @@ button:focus-visible {
   .editor-modal__footer { gap: 6px; }
   .editor-modal__footer .btn { padding: 8px 10px; font-size: 0.78rem; }
 }
+
+/* ============================================================
+   PROJECTOR STATUS
+   ============================================================ */
+
+.proj-status {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 2px 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.proj-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+  transition: background 0.3s;
+}
+
+.proj-dot--connected {
+  background: var(--green);
+  animation: pulse 2s infinite;
+}


### PR DESCRIPTION
Implements a Google Slides presenter-style split: the host runs the existing /hackertheater/ control room while a separate display.html shows only the audience-facing content (video, title, panelist, question card, discussion timer, black/intermission overlays).

Sync is done via BroadcastChannel (live, same origin) with localStorage as a fallback so a projector opened mid-show can restore state.

New files:
- channel.js      — BroadcastChannel + localStorage bridge module
- display.html    — Audience-facing projector page (self-contained)
- display.js      — Projector logic with own YT player + Channel listeners

Modified:
- controller.js   — _broadcast() and _buildSnapshot() for all key events;
                    projector connection status tracking; Open Projector
                    View button wired
- index.html      — Projector panel (button + status pill); channel.js
                    script tag added before clips.js
- styles.css      — Projector status dot styles appended

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i