### PR TITLE
Fix duplicate audio when projector display is open alongside control …

### DIFF
--- a/hackertheater/clips.js
+++ b/hackertheater/clips.js
@@ -16,6 +16,7 @@ const Clips = (() => {
   let player        = null;  // YT.Player object (set at API ready)
   let playerReady   = false; // true only after onReady fires
   let pendingAction = null;  // latest queued action, executed on onReady
+  let pendingMute   = false; // if mute() is called before ready, apply it on onReady
   let pollInterval  = null;
   let endTime       = null;
   let onEndCallback          = null;
@@ -70,6 +71,12 @@ const Clips = (() => {
       const action  = pendingAction;
       pendingAction = null;
       try { action(); } catch (e) { _warn('Pending action threw:', e.message); }
+    }
+
+    // Apply a mute that was requested before the player was ready
+    if (pendingMute) {
+      pendingMute = false;
+      try { player.mute(); } catch (e) { _warn('Deferred mute threw:', e.message); }
     }
   }
 
@@ -207,9 +214,28 @@ const Clips = (() => {
   /** True once the player's onReady event has fired (methods are callable). */
   function isReady() { return playerReady; }
 
+  /** Mute the player. Safe to call before ready — applied on onReady. */
+  function mute() {
+    if (!playerReady) { pendingMute = true; return; }
+    try { player.mute(); } catch (e) { _warn('mute threw:', e.message); }
+  }
+
+  /** Unmute the player. */
+  function unmute() {
+    pendingMute = false;
+    if (!playerReady) return;
+    try { player.unMute(); } catch (e) { _warn('unMute threw:', e.message); }
+  }
+
+  /** Returns true if the player is currently muted. */
+  function isMuted() {
+    if (!playerReady) return false;
+    try { return player.isMuted(); } catch { return false; }
+  }
+
   function setOnEnd(cb)         { onEndCallback         = cb; }
   function setOnStateChange(cb) { onStateChangeCallback = cb; }
 
-  return { cue, play, pause, resume, replay, isPlaying, isReady, setOnEnd, setOnStateChange };
+  return { cue, play, pause, resume, replay, isPlaying, isReady, mute, unmute, isMuted, setOnEnd, setOnStateChange };
 
 })();

--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -229,8 +229,9 @@
   // 7. PROJECTOR CHANNEL
   // ============================================================
 
-  let _lastTimerSave    = 0;
+  let _lastTimerSave     = 0;
   let _lastProjectorPing = 0;
+  let projectorConnected = false; // true while a display window is actively pinging us
 
   function _buildSnapshot() {
     const seg = segments[currentIndex] || null;
@@ -295,14 +296,25 @@
   }
 
   function _updateProjectorStatus(connected) {
+    const wasConnected = projectorConnected;
+    projectorConnected = connected;
+
+    // Mute/unmute the local player on connection-state transitions so the
+    // projector display is the sole audio source during live presentation.
+    if (connected && !wasConnected) {
+      Clips.mute();
+    } else if (!connected && wasConnected) {
+      Clips.unmute();
+    }
+
     const dot   = $('proj-dot');
     const label = $('proj-label');
     if (!dot || !label) return;
     if (connected) {
-      dot.className   = 'proj-dot proj-dot--connected';
+      dot.className     = 'proj-dot proj-dot--connected';
       label.textContent = 'Projector connected';
     } else {
-      dot.className   = 'proj-dot';
+      dot.className     = 'proj-dot';
       label.textContent = 'Projector not connected';
     }
   }


### PR DESCRIPTION
…room

When both the control room and the projector display are running, both YouTube IFrame players were playing simultaneously with audio, causing doubled/overlapping sound.

Fix: mute the control room's local player the moment the projector display connects, and unmute it if the projector disconnects (so the control room still works standalone with full audio).

The control room player continues to run locally while muted — this is intentional: the end-time poll, playback state machine (idle/playing/ paused/ended), and onEnd callback all depend on the local player being active. Only audio is suppressed; the projector display remains the sole audio source during live presentation.

clips.js:
- Add pendingMute flag: if mute() is called before playerReady, the deferred mute is applied in _onPlayerReady after pendingAction drains
- Add mute()   — calls player.mute(), queues via pendingMute if not ready
- Add unmute() — calls player.unMute(), clears pendingMute
- Add isMuted() — returns player.isMuted() safely
- Export all three on the public API

controller.js:
- Add projectorConnected flag (false by default)
- _updateProjectorStatus(connected): on true→false transition call Clips.unmute(); on false→true transition call Clips.mute()
- The existing heartbeat/ping/pong/requestSync paths already call _updateProjectorStatus, so no other changes needed

Regression:
- Standalone (no projector): control room plays with audio as before
- With projector open: audio only from projector display
- Projector closes/times out: control room unmutes and resumes standalone

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i