### PR TITLE
Fix question card clipping in projector presentation mode

### DIFF
--- a/hackertheater/display.html
+++ b/hackertheater/display.html
@@ -365,7 +365,19 @@
 
     /* Video takes up more vertical space */
     body.presentation-mode .video-wrap {
-      max-width: calc((100vh - 145px) * (16/9));
+      max-width: calc((100vh - 245px) * (16/9));
+      max-width: calc((100dvh - 245px) * (16/9));
+    }
+
+    /* When question is visible, shrink video to share space */
+    body.presentation-mode.question-visible .video-wrap {
+      max-width: calc((68vh - 245px) * (16/9));
+      max-width: calc((68dvh - 245px) * (16/9));
+    }
+    body.presentation-mode.question-visible .question-card {
+      overflow-y: auto;
+      max-height: 30vh;
+      max-height: 30dvh;
     }
 
     /* Segment title/panelist readable from back of room */

--- a/hackertheater/display.js
+++ b/hackertheater/display.js
@@ -208,9 +208,11 @@
     if (snap.questionVisible) {
       dom.questionCard.classList.add('revealed');
       dom.questionText.classList.remove('blurred');
+      document.body.classList.add('question-visible');
     } else {
       dom.questionCard.classList.remove('revealed');
       dom.questionText.classList.add('blurred');
+      document.body.classList.remove('question-visible');
     }
 
     // Timer
@@ -279,6 +281,7 @@
     // Reset question
     dom.questionCard.classList.remove('revealed');
     dom.questionText.classList.add('blurred');
+    document.body.classList.remove('question-visible');
     if (seg.question) dom.questionText.textContent = seg.question;
 
     // Reset timer display
@@ -327,12 +330,14 @@
     if (p.text) dom.questionText.textContent = p.text;
     dom.questionCard.classList.add('revealed');
     dom.questionText.classList.remove('blurred');
+    document.body.classList.add('question-visible');
   });
 
   Channel.on('hideQuestion', () => {
     _noteActivity();
     dom.questionCard.classList.remove('revealed');
     dom.questionText.classList.add('blurred');
+    document.body.classList.remove('question-visible');
   });
 
   Channel.on('startDiscussionTimer', (p) => {


### PR DESCRIPTION
Video max-width formula was reserving only 145px for non-video chrome but actual chrome is ~245px, causing overflow and silent clipping. Also adds question-visible body class so the video shrinks to share vertical space when a question is revealed, preventing cutoff.

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i