### PR TITLE
Fix clip end-timestamp enforcement in control room and projector

### DIFF
--- a/hackertheater/clips.js
+++ b/hackertheater/clips.js
@@ -22,12 +22,16 @@ const Clips = (() => {
   let onEndCallback          = null;
   let onStateChangeCallback  = null;
 
+  // Set to true to log timing events to the console.
+  const DEBUG_TIMING = false;
+
   // Dev-only logging: active on localhost / file:// only
   const DEV = (location.hostname === 'localhost' ||
                location.hostname === '127.0.0.1' ||
                location.protocol === 'file:');
   const _log  = (...a) => { if (DEV) console.log('[Clips]',  ...a); };
   const _warn = (...a) => console.warn('[Clips]', ...a);
+  const _tlog = (...a) => { if (DEBUG_TIMING) console.log('[Clips/Timing]', ...a); };
 
   // ---- YouTube IFrame API bootstrap ----
 
@@ -81,9 +85,18 @@ const Clips = (() => {
   }
 
   function _onPlayerStateChange(event) {
-    _clearPoll();
-    if (event.data === YT.PlayerState.PLAYING) {
-      _startEndPoll();
+    // Only kill the poll for states where we're no longer advancing through time.
+    // Do NOT clear on BUFFERING (3) — we're still playing, just stalled briefly.
+    const s = event.data;
+    if (typeof YT !== 'undefined') {
+      if (s === YT.PlayerState.PLAYING) {
+        _startEndPoll(); // _startEndPoll clears first, so no duplicates
+      } else if (s === YT.PlayerState.PAUSED  ||
+                 s === YT.PlayerState.ENDED   ||
+                 s === YT.PlayerState.CUED    ||
+                 s === -1 /* UNSTARTED */) {
+        _clearPoll();
+      }
     }
     if (typeof onStateChangeCallback === 'function') {
       onStateChangeCallback(event.data);
@@ -108,12 +121,18 @@ const Clips = (() => {
 
   // Poll every 250ms to detect the end timestamp.
   // YT.onStateChange does not fire at arbitrary timestamps.
+  // Tolerance of 0.15s prevents overshooting by one poll tick.
   function _startEndPoll() {
+    _clearPoll(); // prevent duplicate intervals
     if (endTime == null) return;
+    _tlog('poll start, endTime=', endTime);
     pollInterval = setInterval(() => {
       if (!playerReady) return;
       try {
-        if (player.getCurrentTime() >= endTime) {
+        const cur = player.getCurrentTime();
+        _tlog('currentTime=', cur.toFixed(2), '/ endTime=', endTime);
+        if (cur >= endTime - 0.15) {
+          _tlog('auto-stop fired at', cur.toFixed(2));
           _clearPoll();
           player.pauseVideo();
           if (typeof onEndCallback === 'function') onEndCallback();
@@ -126,7 +145,11 @@ const Clips = (() => {
   }
 
   function _clearPoll() {
-    if (pollInterval) { clearInterval(pollInterval); pollInterval = null; }
+    if (pollInterval) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+      _tlog('poll stopped');
+    }
   }
 
   /**

--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -203,12 +203,16 @@
     state.clipState = 'idle';
 
     Clips.setOnEnd(() => {
+      if (DEBUG_TIMING) console.log('[Controller/Timing] onEnd fired for segment', index);
       state.clipState = 'ended';
       setStatus('ended', 'Clip ended');
       state.completed.add(index);
       refreshQueue();
-      revealQuestionCard();
-      startTimer();
+      revealQuestionCard();  // broadcasts showQuestion to projector
+      startTimer();          // broadcasts startDiscussionTimer to projector
+      // Safety-net pause: projector has its own end-poll, but broadcast anyway
+      // in case of timing skew or a disconnected-then-reconnected projector.
+      _broadcast('pause');
       toast('Clip ended — discussion question revealed.', 'info');
     });
 
@@ -349,15 +353,35 @@
   // 8. PLAYBACK CONTROLS
   // ============================================================
 
+  /**
+   * Returns true if seg has valid, usable timestamps (both numbers, end > start).
+   * Shows a toast and returns false otherwise.
+   */
+  function _validateTimestamps(seg) {
+    const start = typeof seg.start === 'number' ? seg.start : null;
+    const end   = typeof seg.end   === 'number' ? seg.end   : null;
+    if (start === null || end === null) {
+      toast('Segment is missing a start or end timestamp — cannot play.', 'error');
+      return false;
+    }
+    if (end <= start) {
+      toast(`Invalid timestamps: end (${end}s) must be greater than start (${start}s).`, 'error');
+      return false;
+    }
+    if (DEBUG_TIMING) console.log('[Controller/Timing] segment start=', start, 'end=', end);
+    return true;
+  }
+
   // Load from segment start and play (first play, or after clip ended).
   function playClipFromStart() {
     const seg = segments[currentIndex];
     if (!seg) return;
     if (!seg.youtubeId) { toast('No YouTube video ID on this segment.', 'error'); return; }
+    if (!_validateTimestamps(seg)) return;
     state.clipState = 'playing';
-    Clips.play(seg.youtubeId, seg.start || 0, seg.end || 0);
+    Clips.play(seg.youtubeId, seg.start, seg.end);
     setStatus('playing', 'Loading…');
-    _broadcast('play', { videoId: seg.youtubeId, start: seg.start || 0, end: seg.end || 0 });
+    _broadcast('play', { videoId: seg.youtubeId, start: seg.start, end: seg.end });
   }
 
   // Resume from the current paused position — no seek.
@@ -394,10 +418,11 @@
   function replayClip() {
     const seg = segments[currentIndex];
     if (!seg || !seg.youtubeId) return;
+    if (!_validateTimestamps(seg)) return;
     state.clipState = 'playing';
-    Clips.replay(seg.start || 0, seg.end || 0);
+    Clips.replay(seg.start, seg.end);
     setStatus('playing', 'Replaying');
-    _broadcast('replay', { start: seg.start || 0, end: seg.end || 0 });
+    _broadcast('replay', { start: seg.start, end: seg.end });
   }
 
   function prevSegment() {
@@ -560,6 +585,9 @@
   // ============================================================
   // 13. KEYBOARD SHORTCUTS
   // ============================================================
+
+  // Set to true to log timing events (segment start/end, auto-stop) to the console.
+  const DEBUG_TIMING = false;
 
   // Set to true to log every handled shortcut to the console.
   const DEBUG_SHORTCUTS = false;

--- a/hackertheater/display.js
+++ b/hackertheater/display.js
@@ -32,11 +32,57 @@
     fsBlocked:    $('fs-blocked'),
   };
 
+  // Set to true to log timing events to the console.
+  const DEBUG_TIMING = false;
+
   // ---- YouTube player ----
 
   let player      = null;
   let playerReady = false;
   let pendingVideoAction = null;   // queued until playerReady
+
+  // ---- End-time enforcement ----
+
+  let endTime       = null;  // current clip end timestamp (seconds), null = no limit
+  let _endPollHandle = null;
+
+  function _startEndPoll() {
+    _clearEndPoll(); // prevent duplicate intervals
+    if (endTime == null || !playerReady) return;
+    if (DEBUG_TIMING) console.log('[Display/Timing] poll start, endTime=', endTime);
+    _endPollHandle = setInterval(() => {
+      if (!playerReady) return;
+      try {
+        const cur = player.getCurrentTime();
+        if (DEBUG_TIMING) console.log('[Display/Timing] currentTime=', cur.toFixed(2), '/ endTime=', endTime);
+        if (cur >= endTime - 0.15) {
+          if (DEBUG_TIMING) console.log('[Display/Timing] auto-stop fired at', cur.toFixed(2));
+          _clearEndPoll();
+          player.pauseVideo();
+          _onDisplayClipEnded();
+        }
+      } catch (e) {
+        console.warn('[Display] end-poll error:', e.message);
+        _clearEndPoll();
+      }
+    }, 250);
+  }
+
+  function _clearEndPoll() {
+    if (_endPollHandle) {
+      clearInterval(_endPollHandle);
+      _endPollHandle = null;
+      if (DEBUG_TIMING) console.log('[Display/Timing] poll stopped');
+    }
+  }
+
+  // Called when the projector's end-poll determines the clip is done.
+  function _onDisplayClipEnded() {
+    // Reveal the question if it isn't already showing
+    dom.questionCard.classList.add('revealed');
+    dom.questionText.classList.remove('blurred');
+    document.body.classList.add('question-visible');
+  }
 
   window.onYouTubeIframeAPIReady = () => {
     try {
@@ -54,8 +100,9 @@
           disablekb:      1,
         },
         events: {
-          onReady: _onPlayerReady,
-          onError: _onPlayerError,
+          onReady:       _onPlayerReady,
+          onError:       _onPlayerError,
+          onStateChange: _onPlayerStateChange,
         },
       });
     } catch (e) {
@@ -75,6 +122,23 @@
 
   function _onPlayerError(ev) {
     console.warn('[Display] YT player error:', ev.data);
+    _clearEndPoll();
+  }
+
+  // Drive end-poll start/stop from actual player state so buffering pauses
+  // don't kill the interval — the poll restarts automatically when PLAYING fires.
+  function _onPlayerStateChange(event) {
+    if (typeof YT === 'undefined') return;
+    const s = event.data;
+    if (s === YT.PlayerState.PLAYING) {
+      _startEndPoll();
+    } else if (s === YT.PlayerState.PAUSED  ||
+               s === YT.PlayerState.ENDED   ||
+               s === YT.PlayerState.CUED    ||
+               s === -1 /* UNSTARTED */) {
+      _clearEndPoll();
+    }
+    // BUFFERING (3): do nothing — poll persists across rebuffer events
   }
 
   function _execVideo(fn) {
@@ -238,6 +302,8 @@
 
     // Video
     if (snap.videoId) {
+      endTime = (snap.videoEnd != null && snap.videoEnd > 0) ? snap.videoEnd : null;
+      if (DEBUG_TIMING) console.log('[Display/Timing] applyFullSync, endTime=', endTime, 'state=', snap.playbackState);
       _execVideo(() => {
         if (snap.playbackState === 'playing') {
           player.loadVideoById({ videoId: snap.videoId, startSeconds: snap.videoStart || 0 });
@@ -289,17 +355,27 @@
     timer.total = timer.remaining = 0;
     _renderTimer();
 
+    // Clear any in-progress end-poll for the previous segment
+    _clearEndPoll();
+    endTime = null;
+
     // Cue the video without playing
     if (seg.youtubeId) {
       _execVideo(() => {
         player.cueVideoById({ videoId: seg.youtubeId, startSeconds: seg.start || 0 });
       });
     }
+    if (DEBUG_TIMING) console.log('[Display/Timing] loadSegment, start=', seg.start, 'end=', seg.end);
   });
 
   Channel.on('play', (p) => {
     _noteActivity();
     if (!p.videoId) return;
+    // Store end time before loading — the state-change handler will start the poll
+    // when PLAYING fires after loadVideoById triggers buffering → playing.
+    endTime = (p.end != null && p.end > 0) ? p.end : null;
+    if (DEBUG_TIMING) console.log('[Display/Timing] play received, start=', p.start, 'end=', endTime);
+    _clearEndPoll();
     _execVideo(() => {
       player.loadVideoById({ videoId: p.videoId, startSeconds: p.start || 0 });
     });
@@ -307,18 +383,23 @@
 
   Channel.on('pause', () => {
     _noteActivity();
+    _clearEndPoll();
     if (playerReady) try { player.pauseVideo(); } catch {}
   });
 
   Channel.on('resume', () => {
     _noteActivity();
     if (!playerReady) return;
+    // endTime retained from the previous play message; poll restarts via onStateChange
     try { player.playVideo(); } catch (e) { console.warn('[Display] resume error:', e.message); }
   });
 
   Channel.on('replay', (p) => {
     _noteActivity();
     if (!playerReady) return;
+    endTime = (p.end != null && p.end > 0) ? p.end : null;
+    if (DEBUG_TIMING) console.log('[Display/Timing] replay received, start=', p.start, 'end=', endTime);
+    _clearEndPoll();
     try {
       player.seekTo(p.start || 0, true);
       player.playVideo();
@@ -359,12 +440,14 @@
 
   Channel.on('blackScreen', () => {
     _noteActivity();
+    _clearEndPoll();
     _activateBlack();
     if (playerReady) try { player.pauseVideo(); } catch {}
   });
 
   Channel.on('intermission', () => {
     _noteActivity();
+    _clearEndPoll();
     _activateIntermission();
     if (playerReady) try { player.pauseVideo(); } catch {}
   });


### PR DESCRIPTION
Root causes fixed:
- display.js had no end-time polling at all; projector played past segment.end forever
- clips.js cleared the end-poll on BUFFERING events, so poll died during rebuffering and never reliably restarted
- No 0.15s tolerance meant a 250ms poll could overshoot by one tick
- setOnEnd callback didn't broadcast pause to projector, leaving it running

Changes:
- clips.js: poll survives BUFFERING (only clears on PAUSED/ENDED/CUED/UNSTARTED); _startEndPoll() calls _clearPoll() first to prevent duplicates; adds 0.15s tolerance; adds DEBUG_TIMING flag
- controller.js: _validateTimestamps() helper called before play/replay; setOnEnd now broadcasts 'pause' as a safety net; adds DEBUG_TIMING flag
- display.js: independent end-time poll mirrors clips.js logic; endTime stored per play/replay/applyFullSync; onStateChange handler drives poll start/stop; blackScreen and intermission handlers clear the poll; DEBUG_TIMING flag

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i