### PR TITLE
Add interaction shield to block direct YouTube iframe clicks

### DIFF
--- a/hackertheater/clips.js
+++ b/hackertheater/clips.js
@@ -69,6 +69,11 @@ const Clips = (() => {
     const ph = document.getElementById('video-placeholder');
     if (ph) ph.classList.add('hidden');
 
+    // Remove the YT iframe from the tab order so keyboard focus can't reach it.
+    // The interaction shield handles pointer blocking; tabindex handles keyboard.
+    const iframe = document.querySelector('#yt-player iframe');
+    if (iframe) iframe.setAttribute('tabindex', '-1');
+
     // Drain any action that arrived before the player was ready
     if (pendingAction) {
       _log('Draining pendingAction');

--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -771,11 +771,46 @@
   }
 
   // ============================================================
-  // 19. BOOT
+  // 19. INTERACTION SHIELD
+  // ============================================================
+
+  /**
+   * Blocks direct pointer interaction with the YouTube iframe.
+   * The app's playback controls are the only intended input path.
+   *
+   * Disabled when:
+   *  - URL contains ?debugPlayer=1
+   *  - show.allowDirectPlayerInteraction === true
+   */
+  function _setupInteractionShield() {
+    const debugByUrl  = new URLSearchParams(location.search).get('debugPlayer') === '1';
+    const debugByShow = show && show.allowDirectPlayerInteraction === true;
+
+    const shield = document.getElementById('video-lock');
+    if (!shield) return;
+
+    if (debugByUrl || debugByShow) {
+      shield.classList.add('video-interaction-lock--disabled');
+      if (debugByUrl || debugByShow) _log && _log('Interaction shield disabled (debug mode)');
+      return;
+    }
+
+    const BLOCK_EVENTS = ['click', 'pointerdown', 'pointerup', 'touchstart', 'dblclick', 'contextmenu'];
+    BLOCK_EVENTS.forEach(type => {
+      shield.addEventListener(type, e => {
+        e.preventDefault();
+        e.stopPropagation();
+      }, { passive: false, capture: true });
+    });
+  }
+
+  // ============================================================
+  // 20. BOOT
   // ============================================================
 
   buildQueue();
   loadSegment(0);
+  _setupInteractionShield();
 
   // Expose API for editor.js
   window.ShowController = {

--- a/hackertheater/display.html
+++ b/hackertheater/display.html
@@ -347,11 +347,22 @@
       padding-top: 4px;
     }
 
+    /* ---- Interaction shield (mirrors control-room .video-interaction-lock) ---- */
+    .video-interaction-lock {
+      position: absolute;
+      inset: 0;
+      z-index: 2;
+      cursor: default;
+      pointer-events: auto;
+    }
+    .video-interaction-lock--disabled { display: none; }
+
     /* ---- Lower-third question overlay (inside .video-wrap) ---- */
     .question-lt {
       display: none; /* hidden outside presentation mode */
       position: absolute;
       bottom: 0; left: 0; right: 0;
+      z-index: 3; /* above the interaction shield (z-index: 2) */
       align-items: flex-start;
       gap: 14px;
       padding: 10px 28px 16px;
@@ -548,6 +559,8 @@
           <span class="question-lt__label">QUESTION</span>
           <span id="question-lt-text" class="question-lt__text"></span>
         </div>
+        <!-- Interaction shield: blocks direct iframe clicks. Disabled by ?debugPlayer=1 -->
+        <div id="video-lock" class="video-interaction-lock" aria-hidden="true"></div>
       </div>
 
       <div class="seg-info">

--- a/hackertheater/display.js
+++ b/hackertheater/display.js
@@ -133,6 +133,11 @@
   function _onPlayerReady() {
     playerReady = true;
     dom.placeholder.classList.add('hidden');
+
+    // Remove the YT iframe from the tab order so keyboard focus can't reach it.
+    const iframe = document.querySelector('#yt-player iframe');
+    if (iframe) iframe.setAttribute('tabindex', '-1');
+
     if (pendingVideoAction) {
       const a = pendingVideoAction;
       pendingVideoAction = null;
@@ -274,6 +279,7 @@
     if (snap.show) {
       dom.eventName.textContent = snap.show.eventName || 'Hacker Theater';
       _applyQuestionDisplayMode(snap.show.questionDisplayMode || 'below-video');
+      _applyPlayerInteractionOverride(snap.show.allowDirectPlayerInteraction);
     }
 
     // Segment info
@@ -483,6 +489,7 @@
     if (p && p.show) {
       dom.eventName.textContent = p.show.eventName || 'Hacker Theater';
       _applyQuestionDisplayMode(p.show.questionDisplayMode || 'below-video');
+      _applyPlayerInteractionOverride(p.show.allowDirectPlayerInteraction);
     }
   });
 
@@ -565,6 +572,41 @@
     _noteActivity();
     _enterPresentationMode();
   });
+
+  // ---- Interaction shield ----
+
+  /**
+   * Blocks direct pointer interaction with the YouTube iframe on the projector.
+   * Disabled by ?debugPlayer=1 in the URL; can also be disabled at runtime
+   * via show.allowDirectPlayerInteraction = true (checked in applyFullSync /
+   * applyShowData channel handlers).
+   */
+  function _setupInteractionShield() {
+    const debugByUrl = new URLSearchParams(location.search).get('debugPlayer') === '1';
+    const shield = document.getElementById('video-lock');
+    if (!shield) return;
+
+    if (debugByUrl) {
+      shield.classList.add('video-interaction-lock--disabled');
+      return;
+    }
+
+    const BLOCK_EVENTS = ['click', 'pointerdown', 'pointerup', 'touchstart', 'dblclick', 'contextmenu'];
+    BLOCK_EVENTS.forEach(type => {
+      shield.addEventListener(type, e => {
+        e.preventDefault();
+        e.stopPropagation();
+      }, { passive: false, capture: true });
+    });
+  }
+
+  function _applyPlayerInteractionOverride(allow) {
+    if (!allow) return;
+    const shield = document.getElementById('video-lock');
+    if (shield) shield.classList.add('video-interaction-lock--disabled');
+  }
+
+  _setupInteractionShield();
 
   // ---- Boot ----
 

--- a/hackertheater/index.html
+++ b/hackertheater/index.html
@@ -74,6 +74,8 @@
           <div class="video-placeholder__icon">▶</div>
           <div class="video-placeholder__text">Select a segment and press Play</div>
         </div>
+        <!-- Interaction shield: blocks direct iframe clicks. Disabled by ?debugPlayer=1 -->
+        <div id="video-lock" class="video-interaction-lock" aria-hidden="true"></div>
       </div>
 
       <!-- Segment Info -->

--- a/hackertheater/styles.css
+++ b/hackertheater/styles.css
@@ -264,6 +264,24 @@ button:focus-visible {
 
 .video-placeholder.hidden { display: none; }
 
+/*
+ * Interaction shield — transparent overlay that blocks direct clicks on the
+ * YouTube iframe. App controls remain the only route into the playback
+ * state machine. Set ?debugPlayer=1 or show.allowDirectPlayerInteraction=true
+ * to disable.
+ */
+.video-interaction-lock {
+  position: absolute;
+  inset: 0;
+  z-index: 2;      /* above iframe (auto) and placeholder (auto) */
+  cursor: default;
+  /* pointer-events: auto is the default; explicit for clarity */
+  pointer-events: auto;
+}
+.video-interaction-lock--disabled {
+  display: none;
+}
+
 /* ---- Segment Info ---- */
 
 .segment-info {


### PR DESCRIPTION
Both the control room and projector now have a transparent .video-interaction-lock div (z-index: 2) layered over the YouTube iframe. It blocks click, pointerdown, pointerup, touchstart, dblclick, and contextmenu events with preventDefault + stopPropagation (capture phase), making the app's own controls the sole path into the playback state machine.

The YouTube iframe is also removed from the tab order (tabindex="-1") once the player is ready, blocking keyboard-driven activation in both the control room (clips.js _onPlayerReady) and the projector (display.js _onPlayerReady).

Debug override: add ?debugPlayer=1 to the URL to disable the shield. The show.allowDirectPlayerInteraction = true flag in show.json also disables it (propagated to the projector via fullSync / applyShowData).

The projector's lower-third question overlay (.question-lt) gets z-index: 3 so it renders above the shield without being blocked.

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i