### PR TITLE
Fix control-room audio leak when projector is connected

### DIFF
--- a/hackertheater/clips.js
+++ b/hackertheater/clips.js
@@ -16,7 +16,11 @@ const Clips = (() => {
   let player        = null;  // YT.Player object (set at API ready)
   let playerReady   = false; // true only after onReady fires
   let pendingAction = null;  // latest queued action, executed on onReady
-  let pendingMute   = false; // if mute() is called before ready, apply it on onReady
+  // Persistent mute intent — survives across loadVideoById calls.
+  // YouTube's mute state can be silently reset when a new video loads;
+  // _shouldBeMuted re-applies the mute inside every exec closure so the
+  // control-room player never leaks audio when a projector is connected.
+  let _shouldBeMuted = false;
   let pollInterval  = null;
   let endTime       = null;
   let onEndCallback          = null;
@@ -82,9 +86,8 @@ const Clips = (() => {
       try { action(); } catch (e) { _warn('Pending action threw:', e.message); }
     }
 
-    // Apply a mute that was requested before the player was ready
-    if (pendingMute) {
-      pendingMute = false;
+    // Re-apply the persistent mute intent if it was set before the player was ready.
+    if (_shouldBeMuted) {
       try { player.mute(); } catch (e) { _warn('Deferred mute threw:', e.message); }
     }
   }
@@ -189,6 +192,8 @@ const Clips = (() => {
     _exec(() => {
       _log('cueVideoById', videoId, '@', startSeconds);
       player.cueVideoById({ videoId, startSeconds: startSeconds || 0 });
+      // Re-apply mute immediately — cueVideoById can reset the player's mute state.
+      if (_shouldBeMuted) try { player.mute(); } catch {}
     });
   }
 
@@ -203,6 +208,8 @@ const Clips = (() => {
     _exec(() => {
       _log('loadVideoById', videoId, '@', startSeconds);
       player.loadVideoById({ videoId, startSeconds: startSeconds || 0 });
+      // Re-apply mute immediately — loadVideoById can reset the player's mute state.
+      if (_shouldBeMuted) try { player.mute(); } catch {}
     });
   }
 
@@ -229,6 +236,8 @@ const Clips = (() => {
       _log('replay @', startSeconds);
       player.seekTo(startSeconds || 0, true);
       player.playVideo();
+      // seekTo + playVideo don't normally reset mute, but re-apply for safety.
+      if (_shouldBeMuted) try { player.mute(); } catch {}
     });
   }
 
@@ -242,15 +251,21 @@ const Clips = (() => {
   /** True once the player's onReady event has fired (methods are callable). */
   function isReady() { return playerReady; }
 
-  /** Mute the player. Safe to call before ready — applied on onReady. */
+  /**
+   * Mute the player and set the persistent mute intent.
+   * The intent is re-applied after every loadVideoById / cueVideoById call
+   * so the player cannot accidentally leak audio when loading new clips.
+   * Safe to call before ready — applied on onReady.
+   */
   function mute() {
-    if (!playerReady) { pendingMute = true; return; }
+    _shouldBeMuted = true;
+    if (!playerReady) return; // _onPlayerReady will apply it
     try { player.mute(); } catch (e) { _warn('mute threw:', e.message); }
   }
 
-  /** Unmute the player. */
+  /** Unmute the player and clear the persistent mute intent. */
   function unmute() {
-    pendingMute = false;
+    _shouldBeMuted = false;
     if (!playerReady) return;
     try { player.unMute(); } catch (e) { _warn('unMute threw:', e.message); }
   }

--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -8,6 +8,11 @@
  */
 
 (async () => {
+  // ?controlAudio=1 keeps the control-room player unmuted during testing.
+  // Default: control room is muted whenever a projector is connected so the
+  // projector is the sole audio source for the audience.
+  const CONTROL_AUDIO_ENABLED = new URLSearchParams(location.search).get('controlAudio') === '1';
+
   // ============================================================
   // 1. LOAD SHOW DATA
   // ============================================================
@@ -303,12 +308,17 @@
     const wasConnected = projectorConnected;
     projectorConnected = connected;
 
-    // Mute/unmute the local player on connection-state transitions so the
-    // projector display is the sole audio source during live presentation.
-    if (connected && !wasConnected) {
-      Clips.mute();
-    } else if (!connected && wasConnected) {
-      Clips.unmute();
+    // Keep the control-room player muted whenever the projector is connected so
+    // the projector is the sole audio source for the audience.
+    // We re-enforce the mute on every call (not just on the transition) because
+    // loadVideoById can silently reset YouTube's mute state after each clip load.
+    // CONTROL_AUDIO_ENABLED (?controlAudio=1) bypasses this for testing.
+    if (!CONTROL_AUDIO_ENABLED) {
+      if (connected) {
+        Clips.mute();
+      } else if (wasConnected) {
+        Clips.unmute();
+      }
     }
 
     const dot   = $('proj-dot');
@@ -316,7 +326,9 @@
     if (!dot || !label) return;
     if (connected) {
       dot.className     = 'proj-dot proj-dot--connected';
-      label.textContent = 'Projector connected';
+      label.textContent = CONTROL_AUDIO_ENABLED
+        ? 'Projector connected (audio on)'
+        : 'Projector connected · CR muted';
     } else {
       dot.className     = 'proj-dot';
       label.textContent = 'Projector not connected';


### PR DESCRIPTION
Root cause: loadVideoById and cueVideoById can silently reset YouTube's mute state, so the mute applied on projector connection was lost on the next Play Clip or segment load. Also, the old logic only muted on the wasConnected→connected transition, so reconnects after a brief gap weren't enforced.

clips.js:
- Replace one-shot pendingMute with persistent _shouldBeMuted flag.
- Re-apply player.mute() inside the exec closure of cue(), play(), and replay() when _shouldBeMuted is true, so every video operation stays muted regardless of YouTube internal state resets.
- mute() sets _shouldBeMuted=true; unmute() clears it.
- _onPlayerReady applies mute if _shouldBeMuted (replaces pendingMute).

controller.js:
- Add CONTROL_AUDIO_ENABLED (?controlAudio=1) debug override.
- _updateProjectorStatus now calls Clips.mute() on every call when connected (not just on the transition), so reconnects and play commands are always enforced.
- Projector status label shows "CR muted" when active, or "(audio on)" when the debug override is in effect.

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i