### PR TITLE
Fix segment row height clipping in Show Editor

### DIFF
--- a/hackertheater/styles.css
+++ b/hackertheater/styles.css
@@ -1219,6 +1219,8 @@ button:focus-visible {
   background: var(--bg-card);
   overflow: hidden;
   transition: border-color 0.15s;
+  flex-shrink: 0;       /* never squish rows in a scrollable flex column */
+  min-height: 68px;     /* enough for SEG label + 2-line title + meta */
 }
 
 .ed-seg-item:hover {
@@ -1233,6 +1235,7 @@ button:focus-visible {
 .ed-seg-item__reorder {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   border-right: 1px solid var(--border);
   flex-shrink: 0;
 }
@@ -1306,6 +1309,7 @@ button:focus-visible {
 .ed-seg-item__actions {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   border-left: 1px solid var(--border);
   flex-shrink: 0;
 }


### PR DESCRIPTION
Flex items in a scrollable column still shrink by default; adding flex-shrink: 0 and min-height: 68px to .ed-seg-item prevents rows from being squished below their content height.

Also add justify-content: space-between to the reorder and action button columns so buttons spread cleanly within taller rows rather than bunching at the top.

https://claude.ai/code/session_014tj4DQqnDTpEC1x8rqiv8i