### PR TITLE
fix: prevent duplicate audio when projector mode is active

### DIFF
--- a/hackertheater/clips.js
+++ b/hackertheater/clips.js
@@ -98,6 +98,9 @@ const Clips = (() => {
     const s = event.data;
     if (typeof YT !== 'undefined') {
       if (s === YT.PlayerState.PLAYING) {
+        // Re-apply the persistent mute intent: YouTube can reset mute state
+        // during video load (loadVideoById starts autoplay, mute may arrive late).
+        if (_shouldBeMuted) try { player.mute(); } catch {}
         _startEndPoll(); // _startEndPoll clears first, so no duplicates
       } else if (s === YT.PlayerState.PAUSED  ||
                  s === YT.PlayerState.ENDED   ||

--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -313,12 +313,20 @@
     // We re-enforce the mute on every call (not just on the transition) because
     // loadVideoById can silently reset YouTube's mute state after each clip load.
     // CONTROL_AUDIO_ENABLED (?controlAudio=1) bypasses this for testing.
+    //
+    // We do NOT unmute on heartbeat timeout: Chrome throttles setInterval in
+    // background tabs to ~60 s, so the projector's 4 s ping becomes a 60 s ping,
+    // falsely triggering the 10 s disconnect threshold and unmuting mid-show.
+    // Once a projector has connected, the control room stays muted for the session.
     if (!CONTROL_AUDIO_ENABLED) {
       if (connected) {
+        if (!wasConnected) {
+          console.log('[Controller] Projector mode started — muting control-room player');
+        }
         Clips.mute();
-      } else if (wasConnected) {
-        Clips.unmute();
+        console.log('[Controller] Control-room preview muted (projector connected, muted:', Clips.isMuted(), ')');
       }
+      // Intentionally no Clips.unmute() here — see note above.
     }
 
     const dot   = $('proj-dot');
@@ -391,6 +399,7 @@
     if (!seg.youtubeId) { toast('No YouTube video ID on this segment.', 'error'); return; }
     if (!_validateTimestamps(seg)) return;
     state.clipState = 'playing';
+    console.log('[Controller] Non-projector player: play()', seg.youtubeId, '@', seg.start, '— muted:', Clips.isMuted());
     Clips.play(seg.youtubeId, seg.start, seg.end);
     setStatus('playing', 'Loading…');
     _broadcast('play', { videoId: seg.youtubeId, start: seg.start, end: seg.end, segmentIndex: currentIndex });
@@ -401,6 +410,7 @@
     const seg = segments[currentIndex];
     if (!seg || !seg.youtubeId) return;
     state.clipState = 'playing';
+    console.log('[Controller] Non-projector player: playVideo() (resume) — muted:', Clips.isMuted());
     Clips.resume();
     setStatus('playing', 'Playing');
     _broadcast('resume');
@@ -432,6 +442,7 @@
     if (!seg || !seg.youtubeId) return;
     if (!_validateTimestamps(seg)) return;
     state.clipState = 'playing';
+    console.log('[Controller] Non-projector player: replay() @', seg.start, '— muted:', Clips.isMuted());
     Clips.replay(seg.start, seg.end);
     setStatus('playing', 'Replaying');
     _broadcast('replay', { start: seg.start, end: seg.end, segmentIndex: currentIndex });

--- a/hackertheater/display.js
+++ b/hackertheater/display.js
@@ -235,7 +235,7 @@
     if (!pendingPlay || !segmentCued || !playerReady) return;
     const pp = pendingPlay;
     pendingPlay = null;
-    if (DEBUG_TIMING) console.log('[Display] draining pendingPlay — seekTo', pp.start, '+ playVideo');
+    console.log('[Display] Projector player: playVideo() — seekTo', pp.start, '(drained pendingPlay)');
     try {
       player.seekTo(pp.start || 0, true);
       player.playVideo();
@@ -513,7 +513,7 @@
       // Segment is already cued — seek to start and play immediately.
       // This is the normal path for a late-joining projector that applyFullSync
       // already cued while the user was navigating to the play button.
-      if (DEBUG_TIMING) console.log('[Display] play — already cued, seekTo', p.start, '+ playVideo');
+      console.log('[Display] Projector player: playVideo() — already cued, seekTo', p.start);
       _execVideo(() => {
         try {
           player.seekTo(p.start || 0, true);
@@ -523,11 +523,12 @@
     } else if (awaitingCue) {
       // Same segment is being cued right now — queue the play.
       // _drainPendingPlay() will fire it when the CUED state event arrives.
-      if (DEBUG_TIMING) console.log('[Display] play — same segment cueing in progress, queuing pendingPlay');
+      console.log('[Display] Projector player: play queued — same segment cueing in progress, start=', p.start);
       pendingPlay = { videoId: p.videoId, start: p.start || 0, end: p.end };
     } else {
       // Different segment or no cue in progress — update tracking and do a full load.
-      if (DEBUG_TIMING) console.log('[Display] play — new/uncued segment, loadVideoById');
+      // loadVideoById auto-plays, so this is an implicit playVideo call.
+      console.log('[Display] Projector player: loadVideoById (auto-play) —', p.videoId, '@', p.start);
       currentSegment = { videoId: p.videoId, start: p.start || 0, end: p.end, index: p.segmentIndex != null ? p.segmentIndex : null };
       segmentCued    = false;
       pendingPlay    = null;
@@ -547,6 +548,7 @@
     _noteActivity();
     _lastCommand = { type: 'resume', payload: null, ts: Date.now() };
     if (!playerReady) return;
+    console.log('[Display] Projector player: playVideo() (resume)');
     // endTime retained from the previous play message; poll restarts via onStateChange
     try { player.playVideo(); } catch (e) { console.warn('[Display] resume error:', e.message); }
   });
@@ -560,6 +562,7 @@
     _clearEndPoll();
     // Replay always seeks to start — no readiness gate needed since the video
     // must already have been loaded to be replayable.
+    console.log('[Display] Projector player: playVideo() (replay) — seekTo', p.start || 0);
     try {
       player.seekTo(p.start || 0, true);
       player.playVideo();


### PR DESCRIPTION
Root cause: Chrome throttles setInterval in background tabs to ~60 s. The projector's 4 s ping slowed to 60 s, falsely tripping the 10 s heartbeat-disconnect threshold in controller.js, which called Clips.unmute() mid-show. The next playback command then played audio from both the control-room player and the projector.

Changes:
- controller.js: remove Clips.unmute() from the heartbeat-disconnect path. Once a projector connects, the control room stays muted for the session. The status pill still updates for UI feedback. Add console logs for projector-mode start, control-room mute, and every non-projector playVideo/play/resume/replay call.
- clips.js: re-apply _shouldBeMuted inside onPlayerStateChange(PLAYING) so YouTube's internal mute reset (which can happen during video load) is corrected the moment the player actually starts playing.
- display.js: add console logs for every projector playVideo() call (play, resume, replay, and drained pendingPlay paths).

https://claude.ai/code/session_018kdLGX2XKvpjaFBeFKPALE