### PR TITLE
fix: prevent multiple projector windows causing duplicate audio

### DIFF
--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -743,7 +743,13 @@
   wireBtn('btn-timer-pause', pauseTimer);
   wireBtn('btn-timer-reset', resetTimer);
   wireBtn('btn-projector', () => {
-    window.open('./display.html', 'hackertheater-projector', 'noopener');
+    // Do NOT pass 'noopener' here: the HTML spec forces the window name to the
+    // empty string when noopener is set, which makes the named-target
+    // deduplication ('hackertheater-projector') completely ineffective — every
+    // button click opens a new window. Multiple windows each receive every
+    // BroadcastChannel play/resume command, causing duplicate audio.
+    // Both pages are same-origin so the opener reference carries no new risk.
+    window.open('./display.html', 'hackertheater-projector');
   });
   wireBtn('btn-enter-presentation', () => _broadcast('enterPresentationMode'));
 


### PR DESCRIPTION
window.open with 'noopener' forces the new window's browsing-context name to the empty string per the HTML spec, making the named-target 'hackertheater-projector' ineffective. Every click on the projector button opened a fresh window; each window subscribed to the BroadcastChannel and played audio independently, producing the duplicate audio the user heard.

Removing 'noopener' restores named-window deduplication: subsequent clicks focus the existing projector window instead of spawning another. Both pages are same-origin so the opener reference carries no new risk.

https://claude.ai/code/session_018kdLGX2XKvpjaFBeFKPALE