### PR TITLE
Fix duplicate audio and repeated projector play commands

### DIFF
--- a/hackertheater/clips.js
+++ b/hackertheater/clips.js
@@ -88,7 +88,8 @@ const Clips = (() => {
 
     // Re-apply the persistent mute intent if it was set before the player was ready.
     if (_shouldBeMuted) {
-      try { player.mute(); } catch (e) { _warn('Deferred mute threw:', e.message); }
+      try { player.mute();        } catch (e) { _warn('Deferred mute threw:', e.message); }
+      try { player.setVolume(0);  } catch (e) { _warn('Deferred setVolume(0) threw:', e.message); }
     }
   }
 
@@ -100,7 +101,7 @@ const Clips = (() => {
       if (s === YT.PlayerState.PLAYING) {
         // Re-apply the persistent mute intent: YouTube can reset mute state
         // during video load (loadVideoById starts autoplay, mute may arrive late).
-        if (_shouldBeMuted) try { player.mute(); } catch {}
+        if (_shouldBeMuted) { try { player.mute(); } catch {} try { player.setVolume(0); } catch {} }
         _startEndPoll(); // _startEndPoll clears first, so no duplicates
       } else if (s === YT.PlayerState.PAUSED  ||
                  s === YT.PlayerState.ENDED   ||
@@ -196,7 +197,7 @@ const Clips = (() => {
       _log('cueVideoById', videoId, '@', startSeconds);
       player.cueVideoById({ videoId, startSeconds: startSeconds || 0 });
       // Re-apply mute immediately — cueVideoById can reset the player's mute state.
-      if (_shouldBeMuted) try { player.mute(); } catch {}
+      if (_shouldBeMuted) { try { player.mute(); } catch {} try { player.setVolume(0); } catch {} }
     });
   }
 
@@ -212,7 +213,7 @@ const Clips = (() => {
       _log('loadVideoById', videoId, '@', startSeconds);
       player.loadVideoById({ videoId, startSeconds: startSeconds || 0 });
       // Re-apply mute immediately — loadVideoById can reset the player's mute state.
-      if (_shouldBeMuted) try { player.mute(); } catch {}
+      if (_shouldBeMuted) { try { player.mute(); } catch {} try { player.setVolume(0); } catch {} }
     });
   }
 
@@ -240,7 +241,7 @@ const Clips = (() => {
       player.seekTo(startSeconds || 0, true);
       player.playVideo();
       // seekTo + playVideo don't normally reset mute, but re-apply for safety.
-      if (_shouldBeMuted) try { player.mute(); } catch {}
+      if (_shouldBeMuted) { try { player.mute(); } catch {} try { player.setVolume(0); } catch {} }
     });
   }
 
@@ -263,7 +264,8 @@ const Clips = (() => {
   function mute() {
     _shouldBeMuted = true;
     if (!playerReady) return; // _onPlayerReady will apply it
-    try { player.mute(); } catch (e) { _warn('mute threw:', e.message); }
+    try { player.mute();       } catch (e) { _warn('mute threw:', e.message); }
+    try { player.setVolume(0); } catch (e) { _warn('setVolume(0) threw:', e.message); }
   }
 
   /** Unmute the player and clear the persistent mute intent. */
@@ -273,10 +275,13 @@ const Clips = (() => {
     try { player.unMute(); } catch (e) { _warn('unMute threw:', e.message); }
   }
 
-  /** Returns true if the player is currently muted. */
+  /** Returns true if the player is currently muted. Falls back to _shouldBeMuted so the return is never undefined. */
   function isMuted() {
-    if (!playerReady) return false;
-    try { return player.isMuted(); } catch { return false; }
+    if (!playerReady) return _shouldBeMuted;
+    try {
+      const result = player.isMuted();
+      return result !== undefined ? result : _shouldBeMuted;
+    } catch { return _shouldBeMuted; }
   }
 
   function setOnEnd(cb)         { onEndCallback         = cb; }

--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -202,6 +202,7 @@
       toast(`Segment ${index + 1} has no YouTube video ID — video skipped.`, 'error');
       setStatus('error', 'No video ID configured');
     } else {
+      ensureControllerMuted('cue');
       Clips.cue(seg.youtubeId, seg.start || 0, seg.end || 0);
     }
 
@@ -304,6 +305,19 @@
     }, 5000);
   }
 
+  /**
+   * Enforce mute on the controller preview player before any load/play/seek call.
+   * Guards against YouTube silently resetting the mute state across video loads.
+   * No-op when CONTROL_AUDIO_ENABLED or when no projector is connected.
+   */
+  function ensureControllerMuted(reason) {
+    if (CONTROL_AUDIO_ENABLED) return;
+    if (!projectorConnected) return;
+    Clips.mute(); // sets _shouldBeMuted + calls player.mute() + setVolume(0)
+    console.log('[Controller] Controller preview muted before', reason,
+                '(projector owns audio, muted:', Clips.isMuted(), ')');
+  }
+
   function _updateProjectorStatus(connected) {
     const wasConnected = projectorConnected;
     projectorConnected = connected;
@@ -399,7 +413,10 @@
     if (!seg.youtubeId) { toast('No YouTube video ID on this segment.', 'error'); return; }
     if (!_validateTimestamps(seg)) return;
     state.clipState = 'playing';
-    console.log('[Controller] Non-projector player: play()', seg.youtubeId, '@', seg.start, '— muted:', Clips.isMuted());
+    ensureControllerMuted('play');
+    console.log('[Controller] Controller preview play:', seg.youtubeId, '@', seg.start,
+                '— projector:', projectorConnected ? 'owns audio' : 'not connected',
+                '— muted:', Clips.isMuted());
     Clips.play(seg.youtubeId, seg.start, seg.end);
     setStatus('playing', 'Loading…');
     _broadcast('play', { videoId: seg.youtubeId, start: seg.start, end: seg.end, segmentIndex: currentIndex });
@@ -410,7 +427,8 @@
     const seg = segments[currentIndex];
     if (!seg || !seg.youtubeId) return;
     state.clipState = 'playing';
-    console.log('[Controller] Non-projector player: playVideo() (resume) — muted:', Clips.isMuted());
+    ensureControllerMuted('resume');
+    console.log('[Controller] Controller preview resume — muted:', Clips.isMuted());
     Clips.resume();
     setStatus('playing', 'Playing');
     _broadcast('resume');
@@ -442,7 +460,8 @@
     if (!seg || !seg.youtubeId) return;
     if (!_validateTimestamps(seg)) return;
     state.clipState = 'playing';
-    console.log('[Controller] Non-projector player: replay() @', seg.start, '— muted:', Clips.isMuted());
+    ensureControllerMuted('replay');
+    console.log('[Controller] Controller preview replay @ ', seg.start, '— muted:', Clips.isMuted());
     Clips.replay(seg.start, seg.end);
     setStatus('playing', 'Replaying');
     _broadcast('replay', { start: seg.start, end: seg.end, segmentIndex: currentIndex });

--- a/hackertheater/display.js
+++ b/hackertheater/display.js
@@ -83,6 +83,21 @@
   let _retryCount     = 0;
   let _lastCommand    = null;
 
+  // Deduplication: ignore repeated projector commands with the same key within 400ms.
+  let _lastProjectorCommandKey = null;
+  let _lastProjectorCommandTs  = 0;
+  const PROJECTOR_DEDUP_MS = 400;
+
+  function _isDuplicateCommand(key) {
+    const now = Date.now();
+    if (key === _lastProjectorCommandKey && (now - _lastProjectorCommandTs) < PROJECTOR_DEDUP_MS) {
+      return true;
+    }
+    _lastProjectorCommandKey = key;
+    _lastProjectorCommandTs  = now;
+    return false;
+  }
+
   // ---- End-time enforcement ----
 
   let endTime       = null;  // current clip end timestamp (seconds), null = no limit
@@ -497,6 +512,13 @@
     if (!p.videoId) return;
     _lastCommand = { type: 'play', payload: p, ts: Date.now() };
 
+    // Deduplicate: ignore the same play command arriving within PROJECTOR_DEDUP_MS.
+    const cmdKey = `play:${p.videoId}:${p.start}:${p.segmentIndex}`;
+    if (_isDuplicateCommand(cmdKey)) {
+      console.log('[Display] Projector duplicate play ignored:', cmdKey);
+      return;
+    }
+
     endTime = (p.end != null && p.end > 0) ? p.end : null;
     _clearEndPoll();
 
@@ -521,10 +543,18 @@
         } catch (e) { console.warn('[Display] play (cued) error:', e.message); }
       });
     } else if (awaitingCue) {
-      // Same segment is being cued right now — queue the play.
-      // _drainPendingPlay() will fire it when the CUED state event arrives.
-      console.log('[Display] Projector player: play queued — same segment cueing in progress, start=', p.start);
-      pendingPlay = { videoId: p.videoId, start: p.start || 0, end: p.end };
+      // Same segment is being cued right now — store at most one pending play.
+      // If an identical pendingPlay is already queued, skip to avoid duplicates.
+      if (pendingPlay && pendingPlay.videoId === p.videoId && pendingPlay.start === (p.start || 0)) {
+        console.log('[Display] Projector duplicate pendingPlay ignored — same segment already queued, start=', p.start);
+      } else {
+        if (pendingPlay) {
+          console.log('[Display] pendingPlay replaced instead of appended — old start=', pendingPlay.start, 'new start=', p.start);
+        } else {
+          console.log('[Display] Projector player: play queued — same segment cueing in progress, start=', p.start);
+        }
+        pendingPlay = { videoId: p.videoId, start: p.start || 0, end: p.end };
+      }
     } else {
       // Different segment or no cue in progress — update tracking and do a full load.
       // loadVideoById auto-plays, so this is an implicit playVideo call.
@@ -548,6 +578,10 @@
     _noteActivity();
     _lastCommand = { type: 'resume', payload: null, ts: Date.now() };
     if (!playerReady) return;
+    if (_isDuplicateCommand('resume')) {
+      console.log('[Display] Projector duplicate resume ignored');
+      return;
+    }
     console.log('[Display] Projector player: playVideo() (resume)');
     // endTime retained from the previous play message; poll restarts via onStateChange
     try { player.playVideo(); } catch (e) { console.warn('[Display] resume error:', e.message); }
@@ -557,6 +591,11 @@
     _noteActivity();
     _lastCommand = { type: 'replay', payload: p, ts: Date.now() };
     if (!playerReady) return;
+    const cmdKey = `replay:${p.start}`;
+    if (_isDuplicateCommand(cmdKey)) {
+      console.log('[Display] Projector duplicate replay ignored:', cmdKey);
+      return;
+    }
     endTime = (p.end != null && p.end > 0) ? p.end : null;
     if (DEBUG_TIMING) console.log('[Display] replay received, start=', p.start, 'end=', endTime);
     _clearEndPoll();


### PR DESCRIPTION
clips.js:
- mute() now also calls setVolume(0) for belt-and-suspenders audio suppression
- Re-apply setVolume(0) alongside mute() in every play/cue/replay exec closure and in the PLAYING state-change handler
- isMuted() no longer returns undefined — falls back to _shouldBeMuted

controller.js:
- Add ensureControllerMuted(reason) helper; enforces Clips.mute() before every cue/play/resume/replay call when projector is connected
- Replace ambiguous "Non-projector player" logs with descriptive messages: "Controller preview muted before <action>", "projector owns audio"

display.js:
- Add _isDuplicateCommand(key): ignores repeated projector play/resume/replay commands with the same key within 400ms
- Coalesce pendingPlay: skip identical queued commands; log "pendingPlay replaced instead of appended" when updating a different one
- Log "Projector duplicate play/resume/replay ignored" for suppressed commands

https://claude.ai/code/session_01VRZVXGNkkXYRtstbDRrgaj