### PR TITLE
Fix intermission countdown to count down (MM:SS)

### DIFF
--- a/hackertheater/controller.js
+++ b/hackertheater/controller.js
@@ -12,6 +12,8 @@
   // Default: control room is muted whenever a projector is connected so the
   // projector is the sole audio source for the audience.
   const CONTROL_AUDIO_ENABLED = new URLSearchParams(location.search).get('controlAudio') === '1';
+  const INTERMISSION_DURATION_MS = 10 * 60 * 1000;
+
 
   // ============================================================
   // 1. LOAD SHOW DATA
@@ -82,6 +84,7 @@
     blackActive:       false,
     intermActive:      false,
     intermClockHandle: null,
+    intermEndsAt:      null,
     // Explicit clip lifecycle: idle → playing ↔ paused → ended
     // 'idle'   = segment loaded but never played yet
     // 'playing'= actively playing
@@ -323,6 +326,7 @@
       timerRemaining:  state.timerRemaining,
       timerRunning:    state.timerRunning,
       overlay:         state.blackActive ? 'black' : (state.intermActive ? 'intermission' : 'none'),
+      intermissionEndsAt: state.intermEndsAt,
     };
   }
 
@@ -856,25 +860,30 @@
 
   function activateIntermission() {
     state.intermActive = true;
+    state.intermEndsAt = Date.now() + INTERMISSION_DURATION_MS;
     dom.intermOverlay.classList.add('active');
     if (Clips.isPlaying()) Clips.pause();
+    clearInterval(state.intermClockHandle);
     updateIntermClock();
     state.intermClockHandle = setInterval(updateIntermClock, 1000);
-    _broadcast('intermission');
+    _broadcast('intermission', { endsAt: state.intermEndsAt });
   }
 
   function deactivateIntermission() {
     state.intermActive = false;
+    state.intermEndsAt = null;
     dom.intermOverlay.classList.remove('active');
     clearInterval(state.intermClockHandle);
+    state.intermClockHandle = null;
     _broadcast('clearOverlay');
   }
 
   function updateIntermClock() {
-    const now = new Date();
-    dom.intermClock.textContent = now.toLocaleTimeString([], {
-      hour: '2-digit', minute: '2-digit', second: '2-digit',
-    });
+    const remainingMs = Math.max(0, (state.intermEndsAt || Date.now()) - Date.now());
+    const totalSeconds = Math.ceil(remainingMs / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    dom.intermClock.textContent = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
   }
 
   dom.blackOverlay.addEventListener('click', deactivateBlack);

--- a/hackertheater/display.js
+++ b/hackertheater/display.js
@@ -422,16 +422,26 @@
 
   // ---- Intermission clock ----
 
+  const INTERMISSION_DURATION_MS = 10 * 60 * 1000;
   let _intermHandle = null;
-  function _startIntermClock() {
+  let _intermEndsAt = null;
+  function _startIntermClock(endsAt) {
+    _stopIntermClock();
+    _intermEndsAt = endsAt || (Date.now() + INTERMISSION_DURATION_MS);
     _updateIntermClock();
     _intermHandle = setInterval(_updateIntermClock, 1000);
   }
-  function _stopIntermClock() { clearInterval(_intermHandle); }
+  function _stopIntermClock() {
+    clearInterval(_intermHandle);
+    _intermHandle = null;
+    _intermEndsAt = null;
+  }
   function _updateIntermClock() {
-    dom.intermClock.textContent = new Date().toLocaleTimeString([], {
-      hour: '2-digit', minute: '2-digit', second: '2-digit',
-    });
+    const remainingMs = Math.max(0, (_intermEndsAt || Date.now()) - Date.now());
+    const totalSeconds = Math.ceil(remainingMs / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    dom.intermClock.textContent = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
   }
 
   // ---- Apply full snapshot (from localStorage or fullSync message) ----
@@ -486,7 +496,7 @@
     if (snap.overlay === 'black') {
       _activateBlack();
     } else if (snap.overlay === 'intermission') {
-      _activateIntermission();
+      _activateIntermission(snap.intermissionEndsAt);
     } else {
       _clearOverlays();
     }
@@ -524,10 +534,10 @@
     _stopIntermClock();
   }
 
-  function _activateIntermission() {
+  function _activateIntermission(endsAt) {
     dom.intermOverlay.classList.add('active');
     dom.blackOverlay.classList.remove('active');
-    _startIntermClock();
+    _startIntermClock(endsAt);
   }
 
   function _clearOverlays() {
@@ -884,10 +894,10 @@
     if (playerReady) try { player.pauseVideo(); } catch {}
   });
 
-  Channel.on('intermission', () => {
+  Channel.on('intermission', (payload = {}) => {
     _noteActivity();
     _clearEndPoll('intermission');
-    _activateIntermission();
+    _activateIntermission(payload.endsAt);
     if (playerReady) try { player.pauseVideo(); } catch {}
   });
 


### PR DESCRIPTION
### Motivation
- The intermission overlay currently displayed the current clock time (counting up) instead of a remaining countdown, causing projector and late-join displays to be out of sync.

### Description
- Added a 10-minute default `INTERMISSION_DURATION_MS` and a persistent `state.intermEndsAt` timestamp in `hackertheater/controller.js` to mark when intermission should end.
- Broadcast the intermission end time with `_broadcast('intermission', { endsAt })` and include `intermissionEndsAt` in the snapshot returned by `_buildSnapshot` so late-joining displays restore the same countdown.
- Reworked the UI clock logic in `hackertheater/controller.js` and `hackertheater/display.js` to render remaining time as `MM:SS` (`updateIntermClock` / `_updateIntermClock`) and to start/stop interval handles using the shared `endsAt` value.
- Updated channel handlers so the projector `Channel.on('intermission', ...)` accepts `payload.endsAt` and `applyFullSync` uses `snap.intermissionEndsAt` to resume the countdown.

### Testing
- Performed static checks with `node --check hackertheater/controller.js` which succeeded. 
- Performed static checks with `node --check hackertheater/display.js` which succeeded. 
- Ran `git diff --check` to ensure no whitespace/merge issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61e10ebcf08329bf6dc901bf78bf60)